### PR TITLE
Reorganise imports in test files

### DIFF
--- a/tests/test_core/test_attributemeta.py
+++ b/tests/test_core/test_attributemeta.py
@@ -1,15 +1,14 @@
+import sys
+import os
 import unittest
 from collections import OrderedDict
-
-from malcolm.core.attributemeta import AttributeMeta
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from pkg_resources import require
 require("mock")
 from mock import MagicMock
 
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from malcolm.core.attributemeta import AttributeMeta
 
 
 class TestInit(unittest.TestCase):

--- a/tests/test_core/test_attributemeta.py
+++ b/tests/test_core/test_attributemeta.py
@@ -1,5 +1,3 @@
-#!/bin/env dls-python
-
 import unittest
 from collections import OrderedDict
 

--- a/tests/test_core/test_mapmeta.py
+++ b/tests/test_core/test_mapmeta.py
@@ -1,5 +1,3 @@
-#!/bin/env dls-python
-
 import unittest
 from collections import OrderedDict
 

--- a/tests/test_core/test_mapmeta.py
+++ b/tests/test_core/test_mapmeta.py
@@ -1,15 +1,14 @@
 import unittest
-from collections import OrderedDict
-
-from malcolm.core.mapmeta import MapMeta
-
-import sys
 import os
+import sys
+from collections import OrderedDict
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from pkg_resources import require
 require("mock")
 from mock import MagicMock, patch, call
+
+from malcolm.core.mapmeta import MapMeta
 
 
 class TestInit(unittest.TestCase):

--- a/tests/test_core/test_method.py
+++ b/tests/test_core/test_method.py
@@ -1,4 +1,3 @@
-#!/bin/env dls-python
 import unittest
 import sys
 import os

--- a/tests/test_core/test_stringmeta.py
+++ b/tests/test_core/test_stringmeta.py
@@ -1,12 +1,11 @@
+import sys
+import os
 import unittest
 from collections import OrderedDict
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from malcolm.core.stringmeta import StringMeta
 from malcolm.core.attributemeta import AttributeMeta
-
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 
 class TestInit(unittest.TestCase):

--- a/tests/test_core/test_stringmeta.py
+++ b/tests/test_core/test_stringmeta.py
@@ -1,5 +1,3 @@
-#!/bin/env dls-python
-
 import unittest
 from collections import OrderedDict
 

--- a/tests/test_wscomms/test_wsclientcomms.py
+++ b/tests/test_wscomms/test_wsclientcomms.py
@@ -1,5 +1,8 @@
 import unittest
+import os
+import sys
 from collections import OrderedDict
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from pkg_resources import require
 require("mock")
@@ -92,3 +95,6 @@ class TestWSServerComms(unittest.TestCase):
 
         loop_mock.add_callback.assert_called_once_with(ioloop_mock.current().stop)
         self.WS._loop_spawned.wait.assert_called_once_with()
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Incorrectly ordered imports can stop tests from being run on the command line from the test directory.

Also removes remaining references to dls-python.