### PR TITLE
Change Post responses to go through the process queue first.

### DIFF
--- a/malcolm/core/block.py
+++ b/malcolm/core/block.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from malcolm.core.monitorable import Monitorable
+from malcolm.core.process import BlockRespond
 
 
 class Block(Monitorable):
@@ -55,7 +56,9 @@ class Block(Monitorable):
         self.log_debug("Received request %s", request)
         if request.type_ == request.POST:
             method_name = request.endpoint[-1]
-            self._methods[method_name].handle_request(request)
+            response = self._methods[method_name].get_response(request)
+            response = BlockRespond(response, request.response_queue)
+            self.parent.q.put(response)
         else:
             layer = self
             for next_link in request.endpoint[1:]:

--- a/malcolm/core/method.py
+++ b/malcolm/core/method.py
@@ -3,6 +3,7 @@ from inspect import getdoc
 
 from malcolm.core.monitorable import Monitorable
 from malcolm.core.mapmeta import MapMeta, OPTIONAL, REQUIRED
+from malcolm.core.response import Response
 
 
 class Method(Monitorable):
@@ -66,7 +67,7 @@ class Method(Monitorable):
                 self.returns.elements[r_name].validate(r_val)
         return return_val
 
-    def handle_request(self, request):
+    def get_response(self, request):
         """Call exposed function using request parameters and respond with the
         result
 
@@ -79,10 +80,10 @@ class Method(Monitorable):
         except Exception as error:
             self.log_debug("Error raised %s", error.message)
             message = "Method %s raised an error: %s" % (self.name, error.message)
-            request.respond_with_error(message)
+            return Response.Error(request.id_, request.context, message)
         else:
             self.log_debug("Returning result %s", result)
-            request.respond_with_return(result)
+            return Response.Return(request.id_, request.context, value=result)
 
     def to_dict(self):
         """Return ordered dictionary representing Method object."""

--- a/tests/test_core/test_block.py
+++ b/tests/test_core/test_block.py
@@ -98,6 +98,7 @@ class TestHandleRequest(unittest.TestCase):
 
     def setUp(self):
         self.block = Block("TestBlock")
+        self.block.parent = MagicMock()
         self.method = MagicMock()
         self.method.name = "get_things"
         self.response = MagicMock()
@@ -111,7 +112,7 @@ class TestHandleRequest(unittest.TestCase):
 
         self.block.handle_request(request)
 
-        self.method.handle_request.assert_called_once_with(request)
+        self.method.get_response.assert_called_once_with(request)
 
     def test_given_get_then_return_attribute(self):
         self.block.state = MagicMock()

--- a/tests/test_core/test_method.py
+++ b/tests/test_core/test_method.py
@@ -10,6 +10,7 @@ from mock import Mock, patch, call, MagicMock
 
 from malcolm.core.method import Method, takes, returns
 from malcolm.core.mapmeta import OPTIONAL, REQUIRED
+from malcolm.core.response import Response
 
 
 class TestMethod(unittest.TestCase):
@@ -134,9 +135,9 @@ class TestMethod(unittest.TestCase):
         request = Mock(
                 id=(123, Mock()), type="Post", parameters={"first": 2},
                 respond_with_return=Mock())
-        m.handle_request(request)
+        response = m.get_response(request)
         func.assert_called_with({"first": 2})
-        request.respond_with_return.assert_called_with({"output": 1})
+        self.assertEquals({"output":1}, response.value)
 
     def test_handle_request_error(self):
         func = MagicMock()
@@ -147,10 +148,10 @@ class TestMethod(unittest.TestCase):
         m.returns = MagicMock()
         request = MagicMock()
 
-        m.handle_request(request)
-
-        request.respond_with_error.assert_called_once_with(
-            "Method test_method raised an error: Test error")
+        response = m.get_response(request)
+        self.assertEquals(Response.ERROR, response.type_)
+        self.assertEquals(
+            "Method test_method raised an error: Test error", response.message)
 
     def test_to_dict_serialization(self):
         func = Mock(return_value={"out": "dummy"})


### PR DESCRIPTION
Fixes out-of-order messages, where an Update (triggered by a method call
that changes attributes) can arrive after the method's Return message.