### PR TITLE
Refactor test imports to use path management helpers

### DIFF
--- a/malcolm/wscomms/wsservercomms.py
+++ b/malcolm/wscomms/wsservercomms.py
@@ -1,3 +1,8 @@
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 import json
 

--- a/tests/setup_malcolm_paths.py
+++ b/tests/setup_malcolm_paths.py
@@ -1,0 +1,6 @@
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from pkg_resources import require
+require("mock", "numpy", "tornado")

--- a/tests/test_controllers/test_clientcontroller.py
+++ b/tests/test_controllers/test_clientcontroller.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import MagicMock, patch
 
 # logging

--- a/tests/test_controllers/test_countercontroller.py
+++ b/tests/test_controllers/test_countercontroller.py
@@ -1,6 +1,9 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 from mock import Mock
 
 from malcolm.controllers.countercontroller import CounterController

--- a/tests/test_controllers/test_hellocontroller.py
+++ b/tests/test_controllers/test_hellocontroller.py
@@ -1,6 +1,9 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 from mock import Mock
 
 from malcolm.controllers.hellocontroller import HelloController

--- a/tests/test_controllers/util.py
+++ b/tests/test_controllers/util.py
@@ -1,1 +1,0 @@
-../test_core/util.py

--- a/tests/test_core/test_attribute.py
+++ b/tests/test_core/test_attribute.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import Mock, patch
 
 from malcolm.core.attribute import Attribute

--- a/tests/test_core/test_attributemeta.py
+++ b/tests/test_core/test_attributemeta.py
@@ -1,6 +1,11 @@
-from . import util
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
+
+import unittest
 from mock import MagicMock
 
 from malcolm.core.attributemeta import AttributeMeta

--- a/tests/test_core/test_block.py
+++ b/tests/test_core/test_block.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import MagicMock, patch
 
 # module imports

--- a/tests/test_core/test_cache.py
+++ b/tests/test_core/test_cache.py
@@ -1,9 +1,13 @@
+import os
+import sys
 import unittest
 from collections import OrderedDict
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 
-from . import util
+import setup_malcolm_paths
 from mock import MagicMock
 
 # module imports
@@ -38,3 +42,6 @@ class TestProcess(unittest.TestCase):
         c[1] = {2: {3: "end"}}
         walked = c.walk_path([1, 2, 3])
         self.assertEqual(walked, "end")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core/test_clientcomms.py
+++ b/tests/test_core/test_clientcomms.py
@@ -1,11 +1,16 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import Mock, patch, call
 
 from malcolm.core.clientcomms import ClientComms
 from malcolm.core.syncfactory import SyncFactory
+
 
 class TestClientComms(unittest.TestCase):
     @patch("malcolm.core.clientcomms.ClientComms.add_spawn_function")

--- a/tests/test_core/test_controller.py
+++ b/tests/test_core/test_controller.py
@@ -1,6 +1,9 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 from mock import MagicMock, call
 
 # module imports

--- a/tests/test_core/test_loggable.py
+++ b/tests/test_core/test_loggable.py
@@ -1,6 +1,9 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 from mock import patch
 
 from malcolm.core.loggable import Loggable

--- a/tests/test_core/test_mapmeta.py
+++ b/tests/test_core/test_mapmeta.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import MagicMock, patch, call
 
 from malcolm.core.mapmeta import MapMeta

--- a/tests/test_core/test_method.py
+++ b/tests/test_core/test_method.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import Mock, patch, call, MagicMock
 
 from malcolm.core.method import Method, takes, returns

--- a/tests/test_core/test_monitorable.py
+++ b/tests/test_core/test_monitorable.py
@@ -1,9 +1,13 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 from mock import Mock
 
 from malcolm.core.monitorable import Monitorable
+
 
 class TestMonitorable(unittest.TestCase):
 

--- a/tests/test_core/test_numbermeta.py
+++ b/tests/test_core/test_numbermeta.py
@@ -1,11 +1,16 @@
-from . import util
-import unittest
-from collections import OrderedDict
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
+from collections import OrderedDict
 import numpy as np
+
+import unittest
 
 from malcolm.core.numbermeta import NumberMeta
 from malcolm.core.attributemeta import AttributeMeta
+
 
 class TestNumberMeta(unittest.TestCase):
     def test_init_int(self):

--- a/tests/test_core/test_process.py
+++ b/tests/test_core/test_process.py
@@ -1,9 +1,13 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 
-from . import util
+import unittest
 from mock import MagicMock
 
 # module imports

--- a/tests/test_core/test_request.py
+++ b/tests/test_core/test_request.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import MagicMock, patch
 
 from malcolm.core.request import Request

--- a/tests/test_core/test_response.py
+++ b/tests/test_core/test_response.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 from mock import Mock, MagicMock
 
 from malcolm.core.response import Response

--- a/tests/test_core/test_servercomms.py
+++ b/tests/test_core/test_servercomms.py
@@ -1,11 +1,15 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 from mock import Mock, patch, call
 
 from malcolm.core.servercomms import ServerComms
 from malcolm.core.spawnable import Spawnable
 from malcolm.core.syncfactory import SyncFactory
+
 
 class TestServerComms(unittest.TestCase):
 

--- a/tests/test_core/test_spawnable.py
+++ b/tests/test_core/test_spawnable.py
@@ -1,6 +1,9 @@
+import os
+import sys
 import unittest
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from . import util
+import setup_malcolm_paths
 from mock import Mock, call
 
 from malcolm.core.spawnable import Spawnable

--- a/tests/test_core/test_stringmeta.py
+++ b/tests/test_core/test_stringmeta.py
@@ -1,7 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
+import unittest
 
 from malcolm.core.stringmeta import StringMeta
 from malcolm.core.attributemeta import AttributeMeta

--- a/tests/test_core/test_syncfactory.py
+++ b/tests/test_core/test_syncfactory.py
@@ -1,6 +1,9 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 from mock import patch
 
 # module imports

--- a/tests/test_core/test_system_core.py
+++ b/tests/test_core/test_system_core.py
@@ -1,6 +1,9 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
 
-from . import util
+import unittest
 
 # logging
 # import logging

--- a/tests/test_core/util.py
+++ b/tests/test_core/util.py
@@ -1,6 +1,0 @@
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-
-from pkg_resources import require
-require("mock", "numpy")

--- a/tests/test_wscomms/test_system_wscomms.py
+++ b/tests/test_wscomms/test_system_wscomms.py
@@ -1,15 +1,16 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 import time
-
-from . import util
-
 # logging
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 
+import unittest
+
 # tornado
-from pkg_resources import require
-require("tornado")
 from tornado.websocket import websocket_connect
 from tornado import gen
 from tornado.ioloop import IOLoop

--- a/tests/test_wscomms/test_wsclientcomms.py
+++ b/tests/test_wscomms/test_wsclientcomms.py
@@ -1,9 +1,11 @@
-from . import util
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from pkg_resources import require
-require('tornado')
+import unittest
 from mock import MagicMock, patch, call
 
 from malcolm.wscomms.wsclientcomms import WSClientComms

--- a/tests/test_wscomms/test_wsservercomms.py
+++ b/tests/test_wscomms/test_wsservercomms.py
@@ -1,9 +1,11 @@
-import unittest
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import setup_malcolm_paths
+
 from collections import OrderedDict
 
-from . import util
-from pkg_resources import require
-require('tornado')
+import unittest
 from mock import MagicMock, patch, call
 
 from malcolm.wscomms.wsservercomms import WSServerComms

--- a/tests/test_wscomms/util.py
+++ b/tests/test_wscomms/util.py
@@ -1,1 +1,0 @@
-../test_core/util.py


### PR DESCRIPTION
Replaces a relative import (which prevented tests scripts from simply
being runnable) with a single line of boilerplate to set up the path and
an import that further alters the path as required.