### PR TITLE
Add block_response helper method to process

### DIFF
--- a/malcolm/core/block.py
+++ b/malcolm/core/block.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 from contextlib import contextmanager
 
 from malcolm.core.monitorable import Monitorable
-from malcolm.core.process import BlockRespond
 from malcolm.core.request import Request
 from malcolm.core.response import Response
 
@@ -72,8 +71,7 @@ class Block(Monitorable):
                 self._attributes[attr_name].put(request.value)
                 self._attributes[attr_name].set_value(request.value)
                 response = Response.Return(request.id_, request.context)
-            response = BlockRespond(response, request.response_queue)
-            self.parent.q.put(response)
+            self.parent.block_respond(response, request.response_queue)
 
     def to_dict(self):
         """Convert object attributes into a dictionary"""

--- a/malcolm/core/process.py
+++ b/malcolm/core/process.py
@@ -203,6 +203,9 @@ class Process(Loggable):
         response = Response.Return(request.id_, request.context, d)
         request.response_queue.put(response)
 
+    def block_respond(self, response, response_queue):
+        self.q.put(BlockRespond(response, response_queue))
+
     def notify_subscribers(self, block_name):
         self.q.put(BlockNotify(name=block_name))
 

--- a/tests/test_core/test_block.py
+++ b/tests/test_core/test_block.py
@@ -114,9 +114,9 @@ class TestHandleRequest(unittest.TestCase):
         self.block.handle_request(request)
 
         self.method.get_response.assert_called_once_with(request)
-        response = self.block.parent.q.put.call_args[0][0]
-        self.assertEqual(self.method.get_response.return_value,
-                         response.response)
+        response = self.method.get_response.return_value
+        self.block.parent.block_respond.assert_called_once_with(
+            response, request.response_queue)
 
     def test_given_put_then_update_attribute(self):
         put_value = MagicMock()
@@ -129,9 +129,11 @@ class TestHandleRequest(unittest.TestCase):
 
         self.attribute.put.assert_called_once_with(put_value)
         self.attribute.set_value.assert_called_once_with(put_value)
-        response = self.block.parent.q.put.call_args[0][0]
-        self.assertEqual("Return", response.response.type_)
-        self.assertIsNone(response.response.value)
+        response = self.block.parent.block_respond.call_args[0][0]
+        self.assertEqual("Return", response.type_)
+        self.assertIsNone(response.value)
+        response_queue = self.block.parent.block_respond.call_args[0][1]
+        self.assertEqual(request.response_queue, response_queue)
 
     def test_invalid_request_fails(self):
         request = MagicMock()


### PR DESCRIPTION
Avoids Block needing to know about Process' internal BlockRespond
message.