### PR TITLE
Fix support for areaDetector drivers without 'Multiple' image mode

### DIFF
--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -61,8 +61,12 @@ class DetectorDriverPart(StatefulChildPart):
         else:
             # Leave the arrayCounter where it is, just start from here
             values = {}
+
+        # Not all areaDetector drivers support the imageMode of Multiple
+        if "Multiple" in child.imageMode.meta.choices:
+            values.update(dict(imageMode="Multiple"))
+
         values.update(dict(
-            imageMode="Multiple",
             numImages=steps_to_do,
             arrayCallbacks=True))
         fs = child.put_attribute_values_async(values)

--- a/malcolm/modules/ca/parts/cachoicepart.py
+++ b/malcolm/modules/ca/parts/cachoicepart.py
@@ -1,3 +1,4 @@
+from malcolm.compat import long_
 from malcolm.modules.builtin.vmetas import ChoiceMeta
 from .capart import CAPart
 
@@ -15,9 +16,19 @@ class CAChoicePart(CAPart):
         self.attr.meta.set_choices(value.enums)
 
     def caput(self, value):
-        try:
-            value = self.attr.meta.choices.index(value)
-        except ValueError:
-            # Already have the index
-            pass
+        if isinstance(value, int) or isinstance(value, long_):
+            # Already have the index, so validate it.
+            if value < len(self.attr.meta.choices):
+                pass
+            else:
+                raise ValueError("Provided index %d exceeds list length %d"
+                    % (value, len(self.attr.meta.choices)))
+        else:
+            # Validate that value is in the choices list; if so, get its index
+            if value in self.attr.meta.choices:
+                value = self.attr.meta.choices.index(value)
+            else:
+                raise ValueError("Provided value \"%s\" invalid selection from"
+                    " choices [%s]" %
+                    (value, ", ".join(self.attr.meta.choices)))
         super(CAChoicePart, self).caput(value)

--- a/malcolm/modules/ca/parts/cachoicepart.py
+++ b/malcolm/modules/ca/parts/cachoicepart.py
@@ -22,13 +22,13 @@ class CAChoicePart(CAPart):
                 pass
             else:
                 raise ValueError("Provided index %d exceeds list length %d"
-                    % (value, len(self.attr.meta.choices)))
+                                 % (value, len(self.attr.meta.choices)))
         else:
             # Validate that value is in the choices list; if so, get its index
             if value in self.attr.meta.choices:
                 value = self.attr.meta.choices.index(value)
             else:
                 raise ValueError("Provided value \"%s\" invalid selection from"
-                    " choices [%s]" %
-                    (value, ", ".join(self.attr.meta.choices)))
+                                 " choices [%s]" %
+                                 (value, ", ".join(self.attr.meta.choices)))
         super(CAChoicePart, self).caput(value)

--- a/tests/test_modules/test_ADAndor/test_andordriverpart.py
+++ b/tests/test_modules/test_ADAndor/test_andordriverpart.py
@@ -15,6 +15,8 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         self.child = self.create_child_block(
             andor_detector_driver_block, self.process,
             mri="mri", prefix="prefix")
+        choices = ["Fixed", "Continuous"]
+        self.child.parts["imageMode"].attr.meta.set_choices(choices)
         self.o = call_with_params(
             AndorDriverPart, readoutTime=0.002, name="m", mri="mri")
         list(self.o.create_attribute_models())
@@ -42,7 +44,6 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         assert self.child.handled_requests.mock_calls == [
             call.put('arrayCallbacks', True),
             call.put('arrayCounter', 0),
-            call.put('imageMode', 'Multiple'),
             call.put('numImages', 6000000),
             call.put('exposure', 0.098),
             call.put('acquirePeriod', 0.1),

--- a/tests/test_modules/test_ADSimDetector/test_simdetectordriverpart.py
+++ b/tests/test_modules/test_ADSimDetector/test_simdetectordriverpart.py
@@ -16,6 +16,8 @@ class TestSimDetectorDriverPart(ChildTestCase):
         self.child = self.create_child_block(
             sim_detector_driver_block, self.process,
             mri="mri", prefix="prefix")
+        choices = ["Single", "Multiple", "Continuous"]
+        self.child.parts["imageMode"].attr.meta.set_choices(choices)
         self.o = call_with_params(
             SimDetectorDriverPart, name="m", mri="mri")
         list(self.o.create_attribute_models())

--- a/tests/test_modules/test_adUtil/test_reframepluginpart.py
+++ b/tests/test_modules/test_adUtil/test_reframepluginpart.py
@@ -16,6 +16,8 @@ class TestReframePluginPart(ChildTestCase):
         self.child = self.create_child_block(
             reframe_plugin_block, self.process,
             mri="mri", prefix="prefix")
+        choices = ["Single", "Multiple", "Continuous"]
+        self.child.parts["imageMode"].attr.meta.set_choices(choices)
         self.o = call_with_params(
             ReframePluginPart, name="m", mri="mri")
         list(self.o.create_attribute_models())

--- a/tests/test_modules/test_xspress3/test_xspress3driverpart.py
+++ b/tests/test_modules/test_xspress3/test_xspress3driverpart.py
@@ -15,6 +15,8 @@ class TestXspress3DetectorDriverPart(ChildTestCase):
         self.child = self.create_child_block(
             xspress3_detector_driver_block, self.process,
             mri="mri", prefix="prefix")
+        choices = ["Single", "Multiple", "Continuous"]
+        self.child.parts["imageMode"].attr.meta.set_choices(choices)
         self.o = call_with_params(
             Xspress3DriverPart, readoutTime=0.002, name="m", mri="mri")
         list(self.o.create_attribute_models())


### PR DESCRIPTION
`detectordriverpart.py` and `cachoicepart.py` now check `"Multiple"` is an available `imageMode` before trying to set it, and give a better error if the required `imageMode` is unavailable.  Relevant tests have been updated.