### PR TITLE
New DetectorDriver Part hardware triggering behaviour

### DIFF
--- a/malcolm/modules/ADAndor/blocks/andor_runnable_block.yaml
+++ b/malcolm/modules/ADAndor/blocks/andor_runnable_block.yaml
@@ -31,6 +31,9 @@
 - ADCore.parts.DetectorDriverPart:
     name: DRV
     mri: $(mri_prefix):DRV
+    soft_trigger_modes:
+        - Internal
+        - Software
 
 - ADCore.parts.ExposureDeadtimePart:
     name: DEADTIME

--- a/malcolm/modules/ADCore/parts/__init__.py
+++ b/malcolm/modules/ADCore/parts/__init__.py
@@ -1,7 +1,7 @@
 from .datasetrunnablechildpart import DatasetRunnableChildPart
 from .datasettablepart import DatasetTablePart
 from .detectordriverpart import DetectorDriverPart, APartName, AMri, \
-    AMainDatasetUseful
+    AMainDatasetUseful, ASoftTriggerModes, USoftTriggerModes
 from .exposuredeadtimepart import ExposureDeadtimePart, AInitialAccuracy, \
     AInitialReadoutTime
 from .hdfwriterpart import HDFWriterPart, AFileDir, AFileTemplate, AFormatName

--- a/malcolm/modules/ADCore/parts/__init__.py
+++ b/malcolm/modules/ADCore/parts/__init__.py
@@ -1,7 +1,7 @@
 from .datasetrunnablechildpart import DatasetRunnableChildPart
 from .datasettablepart import DatasetTablePart
 from .detectordriverpart import DetectorDriverPart, APartName, AMri, \
-    AHardwareTriggered, AMainDatasetUseful
+    AMainDatasetUseful
 from .exposuredeadtimepart import ExposureDeadtimePart, AInitialAccuracy, \
     AInitialReadoutTime
 from .hdfwriterpart import HDFWriterPart, AFileDir, AFileTemplate, AFormatName

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -69,9 +69,10 @@ class DetectorDriverPart(ChildPart):
         self.actions.setup_detector(
             context, completed_steps, steps_to_do, **kwargs)
         child = context.block_view(self.mri)
-        tm = getattr(child, "triggerMode")
-        if tm:
-            self.is_hardware_triggered = tm.value not in self.soft_trigger_modes
+        try:  # todo is this the best way to check if the block has triggerMode ??
+            self.is_hardware_triggered = child.triggerMode.value not in self.soft_trigger_modes
+        except KeyError:
+            pass
         # Might need to reset acquirePeriod as it's sometimes wrong
         # in some detectors
         if exposure_info:

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -20,7 +20,7 @@ class DetectorDriverPart(ChildPart):
     def __init__(self,
                  name,  # type: APartName
                  mri,  # type: AMri
-                 soft_trigger_modes=('Internal',),  # type: USoftTriggerModes
+                 soft_trigger_modes=None,  # type: USoftTriggerModes
                  main_dataset_useful=True,  # type: AMainDatasetUseful
                  ):
         # type: (...) -> None
@@ -69,10 +69,8 @@ class DetectorDriverPart(ChildPart):
         self.actions.setup_detector(
             context, completed_steps, steps_to_do, **kwargs)
         child = context.block_view(self.mri)
-        try:  # todo is this the best way to check if the block has triggerMode ??
+        if self.soft_trigger_modes:
             self.is_hardware_triggered = child.triggerMode.value not in self.soft_trigger_modes
-        except KeyError:
-            pass
         # Might need to reset acquirePeriod as it's sometimes wrong
         # in some detectors
         if exposure_info:

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -1,4 +1,4 @@
-from annotypes import Anno, add_call_types, Any
+from annotypes import Anno, add_call_types, Any, Array, Union, Sequence
 
 from malcolm.core import APartName, BadValueError
 from malcolm.modules.builtin.parts import AMri, ChildPart
@@ -9,22 +9,24 @@ from malcolm.modules.scanning.util import AGenerator
 from ..infos import NDArrayDatasetInfo, ExposureDeadtimeInfo
 from ..util import ADBaseActions
 
-with Anno("Is detector hardware triggered?"):
-    AHardwareTriggered = bool
 with Anno("Is main detector dataset useful to publish in DatasetTable?"):
     AMainDatasetUseful = bool
+with Anno("List of trigger modes that do not use hardware triggers"):
+    ASoftTriggerModes = Array[str]
+USoftTriggerModes = Union[ASoftTriggerModes, Sequence[str]]
 
 
 class DetectorDriverPart(ChildPart):
     def __init__(self,
                  name,  # type: APartName
                  mri,  # type: AMri
-                 is_hardware_triggered=True,  # type: AHardwareTriggered
+                 soft_trigger_modes=('Internal',),  # type: USoftTriggerModes
                  main_dataset_useful=True,  # type: AMainDatasetUseful
                  ):
         # type: (...) -> None
         super(DetectorDriverPart, self).__init__(name, mri)
-        self.is_hardware_triggered = is_hardware_triggered
+        self.soft_trigger_modes = soft_trigger_modes
+        self.is_hardware_triggered = True
         self.main_dataset_useful = main_dataset_useful
         self.actions = ADBaseActions(mri)
         # Hooks
@@ -66,10 +68,13 @@ class DetectorDriverPart(ChildPart):
                 generator.duration)
         self.actions.setup_detector(
             context, completed_steps, steps_to_do, **kwargs)
+        child = context.block_view(self.mri)
+        tm = getattr(child, "triggerMode")
+        if tm:
+            self.is_hardware_triggered = tm.value not in self.soft_trigger_modes
         # Might need to reset acquirePeriod as it's sometimes wrong
         # in some detectors
         if exposure_info:
-            child = context.block_view(self.mri)
             child.acquirePeriod.put_value(generator.duration)
         if self.is_hardware_triggered:
             # Start now if we are hardware triggered

--- a/malcolm/modules/ADPandABlocks/parts/pandablocksdriverpart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandablocksdriverpart.py
@@ -7,4 +7,4 @@ class PandABlocksDriverPart(ADCore.parts.DetectorDriverPart,
     def __init__(self, name, mri):
         # type: (ADCore.parts.APartName, ADCore.parts.AMri) -> None
         super(PandABlocksDriverPart, self).__init__(
-            name, mri, main_dataset_useful=False)
+            name, mri, main_dataset_useful=False, soft_trigger_modes=[])

--- a/malcolm/modules/ADPandABlocks/parts/pandablocksdriverpart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandablocksdriverpart.py
@@ -7,4 +7,4 @@ class PandABlocksDriverPart(ADCore.parts.DetectorDriverPart,
     def __init__(self, name, mri):
         # type: (ADCore.parts.APartName, ADCore.parts.AMri) -> None
         super(PandABlocksDriverPart, self).__init__(
-            name, mri, main_dataset_useful=False, soft_trigger_modes=[])
+            name, mri, main_dataset_useful=False)

--- a/malcolm/modules/ADSimDetector/blocks/sim_detector_runnable_block.yaml
+++ b/malcolm/modules/ADSimDetector/blocks/sim_detector_runnable_block.yaml
@@ -42,7 +42,8 @@
 - ADCore.parts.DetectorDriverPart:
     name: DRV
     mri: $(mri_prefix):DRV
-    is_hardware_triggered: False
+    soft_trigger_modes:
+        - Internal
 
 - ADCore.parts.ExposureDeadtimePart:
     name: DEADTIME

--- a/malcolm/modules/aravisGigE/blocks/aravisGigE_runnable_block.yaml
+++ b/malcolm/modules/aravisGigE/blocks/aravisGigE_runnable_block.yaml
@@ -31,6 +31,8 @@
 - ADCore.parts.DetectorDriverPart:
     name: DRV
     mri: $(mri_prefix):DRV
+    soft_trigger_modes:
+        - Off
 
 - ADCore.parts.ExposureDeadtimePart:
     name: DEADTIME

--- a/malcolm/modules/demo/saved_designs/DETECTOR/demo_design.json
+++ b/malcolm/modules/demo/saved_designs/DETECTOR/demo_design.json
@@ -2,23 +2,23 @@
   "attributes": {
     "layout": {
       "DRV": {
-        "x": 0.0,
+        "x": -267.5, 
         "y": 0.0, 
         "visible": true
       }, 
       "STAT": {
-        "x": 0.0,
-        "y": 0.0,
+        "x": 160.5, 
+        "y": -84.800003051757812, 
         "visible": true
       }, 
       "POS": {
-        "x": 0.0,
+        "x": -53.5, 
         "y": 0.0, 
         "visible": true
       }, 
       "HDF5": {
-        "x": 0.0,
-        "y": 0.0,
+        "x": 160.5, 
+        "y": 84.800003051757812, 
         "visible": true
       }
     }, 
@@ -34,15 +34,15 @@
       "imageMode": "Multiple", 
       "numImages": 30, 
       "triggerMode": "Internal", 
-      "exposure": 0.49996000000000002, 
-      "acquirePeriod": 0.0050000000000000001, 
+      "exposure": 0.49993500000000002, 
+      "acquirePeriod": 0.5, 
       "gainX": 1.0, 
       "gainY": 1.0
     }, 
     "STAT": {
       "arrayCallbacks": true, 
       "arrayCounter": 2571, 
-      "attributesFile": "/tmp/DETECTOR:STAT-attributes.xml", 
+      "attributesFile": "DETECTOR:STAT-attributes.xml", 
       "input": "ADSIM.POS", 
       "enableCallbacks": true, 
       "computeStatistics": true
@@ -69,8 +69,8 @@
       "numCapture": 0, 
       "flushDataPerNFrames": 2, 
       "flushAttrPerNFrames": 2, 
-      "xml": "/tmp/DETECTOR:HDF5-layout.xml", 
-      "filePath": "/tmp/", 
+      "xml": "DETECTOR:HDF5-layout.xml", 
+      "filePath": "/", 
       "fileName": "det", 
       "fileTemplate": "%s%s.h5", 
       "numExtraDims": 1, 

--- a/malcolm/modules/excalibur/parts/excaliburdriverpart.py
+++ b/malcolm/modules/excalibur/parts/excaliburdriverpart.py
@@ -11,6 +11,5 @@ class ExcaliburDriverPart(ADCore.parts.DetectorDriverPart):
                   ):
         # type: (...) -> None
         child = context.block_view(self.mri)
-        self.is_hardware_triggered = child.triggerMode.value != "Internal"
         super(ExcaliburDriverPart, self).configure(
             context, completed_steps, steps_to_do, generator, **kwargs)

--- a/tests/test_modules/test_ADCore/test_detectordriverpart.py
+++ b/tests/test_modules/test_ADCore/test_detectordriverpart.py
@@ -25,7 +25,8 @@ class TestDetectorDriverPart(ChildTestCase):
 
         self.child = self.create_child_block(child_block, self.process)
         self.o = DetectorDriverPart(
-            name="m", mri="mri", is_hardware_triggered=False)
+            name="m", mri="mri", soft_trigger_modes=[''])
+        self.o.is_hardware_triggered = False  # this is for test_run
         self.process.start()
 
     def tearDown(self):


### PR DESCRIPTION
Now provide a list software_trigger_modes to ADCore.parts.DetectorDriverPart
defaults to 'Internal' only.
This list is compared against triggerMode state at configure time.

Replaces explicity passing 'hardware_triggered' flag.