### PR TITLE
Fixed error handling during pause

### DIFF
--- a/malcolm/modules/scanning/controllers/runnablecontroller.py
+++ b/malcolm/modules/scanning/controllers/runnablecontroller.py
@@ -519,3 +519,8 @@ class RunnableController(ManagerController):
         if self.resume_queue:
             self.resume_queue.put(False)
         super(RunnableController, self).do_disable()
+
+    def go_to_error_state(self, exception):
+        if self.resume_queue:
+            self.resume_queue.put(False)
+        super(RunnableController, self).go_to_error_state(exception)


### PR DESCRIPTION
Changed behaviour so any error thrown whilst pausing causes the scan run to return as aborted. Also added unit tests for this.