### PR TITLE
HDF NDattributes

### DIFF
--- a/malcolm/core/info.py
+++ b/malcolm/core/info.py
@@ -60,20 +60,23 @@ class Info(object):
         return filtered
 
     @classmethod
-    def filter_single_value(cls, part_info):
-        # type: (Type[T], PartInfo) -> T
+    def filter_single_value(cls, part_info, error_msg=None):
+        # type: (Type[T], PartInfo, str) -> T
         """Filter the part_info dict list looking for a single instance of our
         class
 
         Args:
             part_info (dict): {part_name: [Info] or None} as returned from
                 Controller.run_hook()
+            error_msg (str, optional): Specific error message to show if there isn't a single value
 
         Returns:
             info subclass of cls
         """
         filtered = cls.filter_values(part_info)
         if len(filtered) != 1:
-            raise BadValueError("Expected a single %s, got %s of them" % (
-                cls.__name__, len(filtered)))
+            if error_msg is None:
+                error_msg = "Expected a single %s, got %s of them" % \
+                            (cls.__name__, len(filtered))
+            raise BadValueError(error_msg)
         return filtered[0]

--- a/malcolm/core/info.py
+++ b/malcolm/core/info.py
@@ -7,6 +7,7 @@ from .errors import BadValueError
 
 if TYPE_CHECKING:
     from typing import Type, Dict, List, Union, Sequence
+
     PartInfo = Dict[str, Union[None, Sequence]]
 
 T = TypeVar("T")

--- a/malcolm/core/info.py
+++ b/malcolm/core/info.py
@@ -69,7 +69,8 @@ class Info(object):
         Args:
             part_info (dict): {part_name: [Info] or None} as returned from
                 Controller.run_hook()
-            error_msg (str, optional): Specific error message to show if there isn't a single value
+            error_msg (str, optional): Specific error message to show if
+                there isn't a single value
 
         Returns:
             info subclass of cls

--- a/malcolm/core/models.py
+++ b/malcolm/core/models.py
@@ -13,7 +13,6 @@ from .table import Table
 from .tags import Widget, method_return_unpacked
 from .timestamp import TimeStamp
 
-
 if TYPE_CHECKING:
     from typing import Tuple, Type, List, Dict, Callable
 
@@ -528,7 +527,6 @@ with Anno("The units for the value"):
 
 @Serializable.register_subclass("display_t")
 class Display(Model):
-
     __slots__ = ["limitLow", "limitHigh", "description", "precision", "units"]
 
     # noinspection PyPep8Naming
@@ -746,6 +744,7 @@ class ChoiceArrayMeta(ChoiceMeta, VArrayMeta):
 @VMeta.register_annotype_converter(list(_dtype_string_lookup), is_array=True)
 class NumberArrayMeta(NumberMeta, VArrayMeta):
     """Meta object containing information for an array of numerical values"""
+
     def validate(self, value):
         # type: (Any) -> Array
         """Check if the value is valid returns it"""
@@ -876,7 +875,8 @@ class TableMeta(VMeta):
         return Widget.TABLE
 
     @classmethod
-    def from_table(cls, table_cls, description, widget=None, writeable=(), extra_tags=()):
+    def from_table(cls, table_cls, description, widget=None, writeable=(),
+                   extra_tags=()):
         """Create a TableMeta object, using a Table subclass as the spec
 
         Args:

--- a/malcolm/core/models.py
+++ b/malcolm/core/models.py
@@ -876,7 +876,7 @@ class TableMeta(VMeta):
         return Widget.TABLE
 
     @classmethod
-    def from_table(cls, table_cls, description, widget=None, writeable=()):
+    def from_table(cls, table_cls, description, widget=None, writeable=(), extra_tags=()):
         """Create a TableMeta object, using a Table subclass as the spec
 
         Args:
@@ -885,6 +885,7 @@ class TableMeta(VMeta):
             widget: The widget of the created Meta
             writeable: A list of the writeable field names. If there are any
                 writeable fields then the whole Meta is writeable
+            extra_tags: A list of tags to be added to the table meta
             """
         # type: (Type[Table], str, Widget, List[str]) -> TableMeta
         elements = OrderedDict()
@@ -895,7 +896,9 @@ class TableMeta(VMeta):
                   writeable=bool(writeable))
         if widget is None:
             widget = ret.default_widget()
-        ret.set_tags([widget.tag()])
+        tags = [widget.tag()]
+        tags.extend(extra_tags)
+        ret.set_tags(tags)
         ret.set_table_cls(table_cls)
         return ret
 

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -17,17 +17,17 @@ class FilePathTranslatorInfo(Info):
 
     @classmethod
     def translate_filepath(cls, part_info, filepath):
-        translator = cls.filter_single_value(part_info,
-                        "No or multiple FilePathTranslatorPart found:"
-                        " must have exactly 1 if any part in the" 
-                        "AD chain is running on Windows"
-                     )
+        translator = cls.filter_single_value(
+            part_info,
+            "No or multiple FilePathTranslatorPart found: must have exactly "
+            "1 if any part in the AD chain is running on Windows")
         assert filepath.startswith(translator.path_prefix), \
             "filepath %s does not start with expected prefix %s" % (
                 filepath, translator.path_prefix)
-        return filepath.replace(translator.path_prefix,
-                                translator.windows_drive_letter + ":").replace(
-            "/", "\\")
+        return filepath.replace(
+            translator.path_prefix,
+            translator.windows_drive_letter + ":"
+        ).replace("/", "\\")
 
 
 class ExposureDeadtimeInfo(Info):

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -17,10 +17,11 @@ class FilePathTranslatorInfo(Info):
 
     @classmethod
     def translate_filepath(cls, part_info, filepath):
-        error_msg = "No or multiple FilePathTranslatorPart found:" + \
-                    "must have exactly 1 if any part in the" + \
-                    "AD chain is running on Windows"
-        translator = cls.filter_single_value(part_info, error_msg)
+        translator = cls.filter_single_value(part_info,
+                        "No or multiple FilePathTranslatorPart found:"
+                        " must have exactly 1 if any part in the" 
+                        "AD chain is running on Windows"
+                     )
         assert filepath.startswith(translator.path_prefix), \
             "filepath %s does not start with expected prefix %s" % (
                 filepath, translator.path_prefix)

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -3,6 +3,16 @@ from malcolm.core import Info
 from .util import DatasetType, AttributeDatasetType
 
 
+class FilePathTranslatorInfo(Info):
+    def __init__(self, windows_drive_letter, path_prefix):
+        self.windows_drive_letter = windows_drive_letter
+        self.path_prefix = path_prefix
+
+    def translate_filepath(self, filepath):
+        assert filepath.startswith(self.path_prefix), \
+            "filepath %s does not start with expected prefix %s" % (filepath, self.path_prefix)
+        return filepath.replace(self.path_prefix, self.windows_drive_letter + ":").replace("/", "\\")
+
 class ExposureDeadtimeInfo(Info):
     """Detector exposure time should be generator.duration - deadtime
 

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -4,18 +4,29 @@ from .util import DatasetType, AttributeDatasetType
 
 
 class FilePathTranslatorInfo(Info):
+    """Translate linux filepath to windows equivalent
+
+    Args:
+        windows_drive_letter: The drive letter assigned to the windows mount
+        path_prefix: The location of the mount in linux (i.e. /dls or /dls_sw)
+    """
     def __init__(self, windows_drive_letter, path_prefix):
         self.windows_drive_letter = windows_drive_letter
         self.path_prefix = path_prefix
 
-    def translate_filepath(self, filepath):
-        assert filepath.startswith(self.path_prefix), \
-            "filepath %s does not start with expected prefix %s" % (filepath, self.path_prefix)
-        return filepath.replace(self.path_prefix, self.windows_drive_letter + ":").replace("/", "\\")
+    @classmethod
+    def translate_filepath(cls, part_info, filepath):
+        error_msg = "No or multiple FilePathTranslatorPart found:" + \
+                    "must have exactly 1 if any part in the AD chain is running on Windows"
+        translator = cls.filter_single_value(part_info, error_msg)
+        assert filepath.startswith(translator.path_prefix), \
+            "filepath %s does not start with expected prefix %s" % (filepath, translator.path_prefix)
+        return filepath.replace(translator.path_prefix, translator.windows_drive_letter + ":").replace("/", "\\")
+
 
 class ExposureDeadtimeInfo(Info):
     """Detector exposure time should be generator.duration - deadtime
-
+X
     Args:
         readout_time: The per frame readout time of the detector
         frequency_accuracy: The crystal accuracy in ppm

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -10,6 +10,7 @@ class FilePathTranslatorInfo(Info):
         windows_drive_letter: The drive letter assigned to the windows mount
         path_prefix: The location of the mount in linux (i.e. /dls or /dls_sw)
     """
+
     def __init__(self, windows_drive_letter, path_prefix):
         self.windows_drive_letter = windows_drive_letter
         self.path_prefix = path_prefix
@@ -19,8 +20,10 @@ class FilePathTranslatorInfo(Info):
         error_msg = "No or multiple FilePathTranslatorPart found:" + \
                     "must have exactly 1 if any part in the AD chain is running on Windows"
         translator = cls.filter_single_value(part_info, error_msg)
-        assert filepath.startswith(translator.path_prefix), \
-            "filepath %s does not start with expected prefix %s" % (filepath, translator.path_prefix)
+        if not filepath.startswith(translator.path_prefix):
+            raise AssertionError(
+                "filepath %s does not start with expected prefix %s" % (filepath, translator.path_prefix)
+            )
         return filepath.replace(translator.path_prefix, translator.windows_drive_letter + ":").replace("/", "\\")
 
 
@@ -31,6 +34,7 @@ class ExposureDeadtimeInfo(Info):
         readout_time: The per frame readout time of the detector
         frequency_accuracy: The crystal accuracy in ppm
     """
+
     def __init__(self, readout_time, frequency_accuracy):
         # type: (float, float) -> None
         self.readout_time = readout_time
@@ -41,7 +45,7 @@ class ExposureDeadtimeInfo(Info):
         """Calculate the exposure to set the detector to given the duration of
         the frame and the readout_time and frequency_accuracy"""
         exposure = duration - self.frequency_accuracy * duration / 1000000.0 - \
-            self.readout_time
+                   self.readout_time
         assert exposure > 0.0, \
             "Exposure time %s too small when deadtime taken into account" % (
                 exposure,)
@@ -55,6 +59,7 @@ class NDArrayDatasetInfo(Info):
     Args:
         rank: The rank of the dataset, e.g. 2 for a 2D detector
     """
+
     def __init__(self, rank):
         # type: (int) -> None
         self.rank = rank
@@ -68,6 +73,7 @@ class CalculatedNDAttributeDatasetInfo(Info):
         name: Dataset name that should be written to
         attr: NDAttribute name to get data from
     """
+
     def __init__(self, name, attr):
         # type: (str, str) -> None
         self.name = name
@@ -84,6 +90,7 @@ class NDAttributeDatasetInfo(Info):
         attr: NDAttribute name to get data from
         rank: The rank of the dataset
     """
+
     def __init__(self, name, type, attr, rank):
         # type: (str, AttributeDatasetType, str, int) -> None
         self.name = name
@@ -103,6 +110,7 @@ class DatasetProducedInfo(Info):
         path: The path of the dataset within the file
         uniqueid: The path of the UniqueID dataset within the file
     """
+
     def __init__(self, name, filename, type, rank, path, uniqueid):
         # type: (str, str, DatasetType, int, str, str) -> None
         self.name = name
@@ -111,4 +119,3 @@ class DatasetProducedInfo(Info):
         self.rank = rank
         self.path = path
         self.uniqueid = uniqueid
-

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -26,7 +26,7 @@ class FilePathTranslatorInfo(Info):
 
 class ExposureDeadtimeInfo(Info):
     """Detector exposure time should be generator.duration - deadtime
-X
+
     Args:
         readout_time: The per frame readout time of the detector
         frequency_accuracy: The crystal accuracy in ppm

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -10,7 +10,6 @@ class FilePathTranslatorInfo(Info):
         windows_drive_letter: The drive letter assigned to the windows mount
         path_prefix: The location of the mount in linux (i.e. /dls or /dls_sw)
     """
-
     def __init__(self, windows_drive_letter, path_prefix):
         self.windows_drive_letter = windows_drive_letter
         self.path_prefix = path_prefix
@@ -20,10 +19,8 @@ class FilePathTranslatorInfo(Info):
         error_msg = "No or multiple FilePathTranslatorPart found:" + \
                     "must have exactly 1 if any part in the AD chain is running on Windows"
         translator = cls.filter_single_value(part_info, error_msg)
-        if not filepath.startswith(translator.path_prefix):
-            raise AssertionError(
-                "filepath %s does not start with expected prefix %s" % (filepath, translator.path_prefix)
-            )
+        assert filepath.startswith(translator.path_prefix), \
+            "filepath %s does not start with expected prefix %s" % (filepath, translator.path_prefix)
         return filepath.replace(translator.path_prefix, translator.windows_drive_letter + ":").replace("/", "\\")
 
 
@@ -34,7 +31,6 @@ class ExposureDeadtimeInfo(Info):
         readout_time: The per frame readout time of the detector
         frequency_accuracy: The crystal accuracy in ppm
     """
-
     def __init__(self, readout_time, frequency_accuracy):
         # type: (float, float) -> None
         self.readout_time = readout_time
@@ -45,7 +41,7 @@ class ExposureDeadtimeInfo(Info):
         """Calculate the exposure to set the detector to given the duration of
         the frame and the readout_time and frequency_accuracy"""
         exposure = duration - self.frequency_accuracy * duration / 1000000.0 - \
-                   self.readout_time
+            self.readout_time
         assert exposure > 0.0, \
             "Exposure time %s too small when deadtime taken into account" % (
                 exposure,)
@@ -59,7 +55,6 @@ class NDArrayDatasetInfo(Info):
     Args:
         rank: The rank of the dataset, e.g. 2 for a 2D detector
     """
-
     def __init__(self, rank):
         # type: (int) -> None
         self.rank = rank
@@ -73,7 +68,6 @@ class CalculatedNDAttributeDatasetInfo(Info):
         name: Dataset name that should be written to
         attr: NDAttribute name to get data from
     """
-
     def __init__(self, name, attr):
         # type: (str, str) -> None
         self.name = name
@@ -90,7 +84,6 @@ class NDAttributeDatasetInfo(Info):
         attr: NDAttribute name to get data from
         rank: The rank of the dataset
     """
-
     def __init__(self, name, type, attr, rank):
         # type: (str, AttributeDatasetType, str, int) -> None
         self.name = name
@@ -110,7 +103,6 @@ class DatasetProducedInfo(Info):
         path: The path of the dataset within the file
         uniqueid: The path of the UniqueID dataset within the file
     """
-
     def __init__(self, name, filename, type, rank, path, uniqueid):
         # type: (str, str, DatasetType, int, str, str) -> None
         self.name = name
@@ -119,3 +111,4 @@ class DatasetProducedInfo(Info):
         self.rank = rank
         self.path = path
         self.uniqueid = uniqueid
+

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -17,7 +17,9 @@ class FilePathTranslatorInfo(Info):
 
     @classmethod
     def translate_filepath(cls, part_info, filepath):
-        error_msg = "No or multiple FilePathTranslatorPart found: must have exactly 1 if any part in the AD chain is running on Windows"
+        error_msg = "No or multiple FilePathTranslatorPart found:" + \
+                    "must have exactly 1 if any part in the" + \
+                    "AD chain is running on Windows"
         translator = cls.filter_single_value(part_info, error_msg)
         assert filepath.startswith(translator.path_prefix), \
             "filepath %s does not start with expected prefix %s" % (

--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -10,18 +10,21 @@ class FilePathTranslatorInfo(Info):
         windows_drive_letter: The drive letter assigned to the windows mount
         path_prefix: The location of the mount in linux (i.e. /dls or /dls_sw)
     """
+
     def __init__(self, windows_drive_letter, path_prefix):
         self.windows_drive_letter = windows_drive_letter
         self.path_prefix = path_prefix
 
     @classmethod
     def translate_filepath(cls, part_info, filepath):
-        error_msg = "No or multiple FilePathTranslatorPart found:" + \
-                    "must have exactly 1 if any part in the AD chain is running on Windows"
+        error_msg = "No or multiple FilePathTranslatorPart found: must have exactly 1 if any part in the AD chain is running on Windows"
         translator = cls.filter_single_value(part_info, error_msg)
         assert filepath.startswith(translator.path_prefix), \
-            "filepath %s does not start with expected prefix %s" % (filepath, translator.path_prefix)
-        return filepath.replace(translator.path_prefix, translator.windows_drive_letter + ":").replace("/", "\\")
+            "filepath %s does not start with expected prefix %s" % (
+                filepath, translator.path_prefix)
+        return filepath.replace(translator.path_prefix,
+                                translator.windows_drive_letter + ":").replace(
+            "/", "\\")
 
 
 class ExposureDeadtimeInfo(Info):
@@ -31,6 +34,7 @@ class ExposureDeadtimeInfo(Info):
         readout_time: The per frame readout time of the detector
         frequency_accuracy: The crystal accuracy in ppm
     """
+
     def __init__(self, readout_time, frequency_accuracy):
         # type: (float, float) -> None
         self.readout_time = readout_time
@@ -41,7 +45,7 @@ class ExposureDeadtimeInfo(Info):
         """Calculate the exposure to set the detector to given the duration of
         the frame and the readout_time and frequency_accuracy"""
         exposure = duration - self.frequency_accuracy * duration / 1000000.0 - \
-            self.readout_time
+                   self.readout_time
         assert exposure > 0.0, \
             "Exposure time %s too small when deadtime taken into account" % (
                 exposure,)
@@ -55,6 +59,7 @@ class NDArrayDatasetInfo(Info):
     Args:
         rank: The rank of the dataset, e.g. 2 for a 2D detector
     """
+
     def __init__(self, rank):
         # type: (int) -> None
         self.rank = rank
@@ -68,6 +73,7 @@ class CalculatedNDAttributeDatasetInfo(Info):
         name: Dataset name that should be written to
         attr: NDAttribute name to get data from
     """
+
     def __init__(self, name, attr):
         # type: (str, str) -> None
         self.name = name
@@ -84,6 +90,7 @@ class NDAttributeDatasetInfo(Info):
         attr: NDAttribute name to get data from
         rank: The rank of the dataset
     """
+
     def __init__(self, name, type, attr, rank):
         # type: (str, AttributeDatasetType, str, int) -> None
         self.name = name
@@ -103,6 +110,7 @@ class DatasetProducedInfo(Info):
         path: The path of the dataset within the file
         uniqueid: The path of the UniqueID dataset within the file
     """
+
     def __init__(self, name, filename, type, rank, path, uniqueid):
         # type: (str, str, DatasetType, int, str, str) -> None
         self.name = name
@@ -111,4 +119,3 @@ class DatasetProducedInfo(Info):
         self.rank = rank
         self.path = path
         self.uniqueid = uniqueid
-

--- a/malcolm/modules/ADCore/parts/__init__.py
+++ b/malcolm/modules/ADCore/parts/__init__.py
@@ -7,6 +7,7 @@ from .exposuredeadtimepart import ExposureDeadtimePart, AInitialAccuracy, \
 from .hdfwriterpart import HDFWriterPart, AFileDir, AFileTemplate, AFormatName
 from .positionlabellerpart import PositionLabellerPart
 from .statspluginpart import StatsPluginPart
+from .filepathtranslatorpart import FilepathTranslatorPart
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -11,7 +11,7 @@ from malcolm.modules.scanning.hooks import ReportStatusHook, \
 from malcolm.modules.scanning.util import AGenerator
 from ..infos import NDArrayDatasetInfo, NDAttributeDatasetInfo, \
     ExposureDeadtimeInfo, FilePathTranslatorInfo
-from ..util import ADBaseActions, ExtraAttributesTable, AttributeDatasetType, \
+from ..util import ADBaseActions, ExtraAttributesTable, \
     APartRunsOnWindows, DataType, SourceType
 import os
 
@@ -45,8 +45,9 @@ class DetectorDriverPart(ChildPart):
         self.extra_attributes = TableMeta.from_table(
             ExtraAttributesTable, "Extra attributes to be added to the dataset",
             writeable=(
-            "name", "pv", "description", "sourceId", "sourceType", "dataType",
-            "datasetType"),
+                "name", "pv", "description", "sourceId", "sourceType",
+                "dataType",
+                "datasetType"),
             extra_tags=[config_tag()]
         ).create_attribute_model()
         self.runs_on_windows = runs_on_windows
@@ -173,12 +174,9 @@ class DetectorDriverPart(ChildPart):
             if hasattr(child, "attributesFile"):
                 attributes_filename = self.attributes_filename
                 if self.runs_on_windows:
-                    error_msg = "No or multiple FilePathTranslatorPart found:" + \
-                                "must have exactly 1 if any part in the AD chain is running on Windows"
-                    translator = FilePathTranslatorInfo.filter_single_value(
-                        part_info, error_msg)
-                    attributes_filename = translator.translate_filepath(
-                        part_info, self.attributes_filename)
+                    attributes_filename = \
+                        FilePathTranslatorInfo.translate_filepath(
+                         part_info, self.attributes_filename)
                 futures = child.put_attribute_values_async(dict(
                     attributesFile=attributes_filename))
                 context.wait_all_futures(futures)

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -182,7 +182,7 @@ class DetectorDriverPart(ChildPart):
                 context.wait_all_futures(futures)
             else:
                 raise AssertionError(
-                    '''Block doesn't have "attributesFile" attribute''' +
+                    '''Block doesn't have "attributesFile" attribute'''
                     ' (was it instantiated properly with adbase_parts?)')
 
     @add_call_types

--- a/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
+++ b/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
@@ -1,0 +1,55 @@
+from __future__ import division
+
+from annotypes import Anno, add_call_types
+
+from malcolm.core import Part, StringMeta, Widget, config_tag, APartName, \
+    PartRegistrar
+from malcolm.modules import scanning
+from ..infos import FilePathTranslatorInfo
+
+drive_letter_desc = \
+    "Letter assigned to the windows drive mount"
+with Anno(drive_letter_desc):
+    ADriveLetter = str
+path_prefix_desc = \
+    "The first bit of the file path (i.e. /dls for /dls/i18/...)"
+with Anno(path_prefix_desc):
+    APathPrefix = str
+
+
+class FilepathTranslatorPart(Part):
+    def __init__(self,
+                 name,  # type: APartName
+                 default_windows_drive_letter="",  # type: ADriveLetter
+                 default_path_prefix="/dls"  # type: APathPrefix
+                 ):
+        # type: (...) -> None
+        super(FilepathTranslatorPart, self).__init__(name)
+        self.windows_drive_letter = StringMeta(
+            drive_letter_desc,
+            tags=[Widget.TEXTINPUT.tag(), config_tag()],
+        ).create_attribute_model(default_windows_drive_letter)
+        self.path_prefix = StringMeta(
+            path_prefix_desc,
+            tags=[Widget.TEXTINPUT.tag(), config_tag()],
+        ).create_attribute_model(default_path_prefix)
+        # Hooks
+        self.register_hooked(
+            scanning.hooks.ReportStatusHook, self.report_status)
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(FilepathTranslatorPart, self).setup(registrar)
+        # Attributes
+        registrar.add_attribute_model(
+            "windowsDriveLetter", self.windows_drive_letter, self.windows_drive_letter.set_value)
+        registrar.add_attribute_model(
+            "pathPrefix", self.path_prefix,
+            self.path_prefix.set_value)
+
+    @add_call_types
+    def report_status(self):
+        # type: () -> scanning.hooks.UInfos
+        info = FilePathTranslatorInfo(
+            self.windows_drive_letter.value, self.path_prefix.value)
+        return info

--- a/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
+++ b/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
@@ -42,7 +42,8 @@ class FilepathTranslatorPart(Part):
         super(FilepathTranslatorPart, self).setup(registrar)
         # Attributes
         registrar.add_attribute_model(
-            "windowsDriveLetter", self.windows_drive_letter, self.windows_drive_letter.set_value)
+            "windowsDriveLetter", self.windows_drive_letter,
+            self.windows_drive_letter.set_value)
         registrar.add_attribute_model(
             "pathPrefix", self.path_prefix,
             self.path_prefix.set_value)

--- a/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
+++ b/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
@@ -20,19 +20,19 @@ with Anno(path_prefix_desc):
 class FilepathTranslatorPart(Part):
     def __init__(self,
                  name,  # type: APartName
-                 default_windows_drive_letter="",  # type: ADriveLetter
-                 default_path_prefix="/dls"  # type: APathPrefix
+                 initial_windows_drive_letter,  # type: ADriveLetter
+                 initial_path_prefix="/dls"  # type: APathPrefix
                  ):
         # type: (...) -> None
         super(FilepathTranslatorPart, self).__init__(name)
         self.windows_drive_letter = StringMeta(
             drive_letter_desc,
             tags=[Widget.TEXTINPUT.tag(), config_tag()],
-        ).create_attribute_model(default_windows_drive_letter)
+        ).create_attribute_model(initial_windows_drive_letter)
         self.path_prefix = StringMeta(
             path_prefix_desc,
             tags=[Widget.TEXTINPUT.tag(), config_tag()],
-        ).create_attribute_model(default_path_prefix)
+        ).create_attribute_model(initial_path_prefix)
         # Hooks
         self.register_hooked(
             scanning.hooks.ReportStatusHook, self.report_status)

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -247,9 +247,13 @@ def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
 class HDFWriterPart(builtin.parts.ChildPart):
     """Part for controlling an `hdf_writer_block` in a Device"""
 
-    def __init__(self, name, mri, runs_on_windows=False,
-                 write_all_nd_attributes=True):
-        # type: (APartName, scanning.parts.AMri, APartRunsOnWindows, AWriteAllNDAttributes) -> None
+    def __init__(self,
+                 name,                          # type: APartName
+                 mri,                           # type: scanning.parts.AMri
+                 runs_on_windows=False,         # type: APartRunsOnWindows
+                 write_all_nd_attributes=True,  # type: AWriteAllNDAttributes
+                 ):
+        # type: (...) -> None
         super(HDFWriterPart, self).__init__(name, mri)
         # Future for the start action
         self.start_future = None  # type: Future
@@ -261,8 +265,10 @@ class HDFWriterPart(builtin.parts.ChildPart):
         self.layout_filename = None  # type: str
         self.runs_on_windows = runs_on_windows
         # Hooks
+        description = "Toggles whether all NDAttributes are written to " + \
+                      "file, or only those specified in the dataset"
         self.write_all_nd_attributes = BooleanMeta(
-            "Toggles wheteher all NDAttributes are written to file, or only those specified in the dataset",
+            description,
             writeable=True,
             tags=[Widget.CHECKBOX.tag(), config_tag()]).create_attribute_model(
             write_all_nd_attributes)

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -179,7 +179,7 @@ def make_layout_xml(generator, part_info):
     # type: (CompoundGenerator, PartInfo) -> str
     # Make a root element with an NXEntry
     root_el = ET.Element("hdf5_layout")
-    entry_el = ET.SubElement(root_el, "group", name="entry")
+    entry_el = ET.SubElement(root_el, "group", name="entry", auto_ndattr_default="false")
     ET.SubElement(entry_el, "attribute", name="NX_class",
                   source="constant", value="NXentry", type="string")
 
@@ -188,8 +188,10 @@ def make_layout_xml(generator, part_info):
     if not ndarray_infos:
         # Still need to put the data in the file, so manufacture something
         primary_rank = 1
+        nd_attributes = []
     else:
         primary_rank = ndarray_infos[0].rank
+        nd_attributes = []
 
     # Make an NXData element with the detector data in it in
     # /entry/detector/detector
@@ -219,9 +221,14 @@ def make_layout_xml(generator, part_info):
 
     # Add a group for attributes
     NDAttributes_el = ET.SubElement(entry_el, "group", name="NDAttributes",
-                                    ndattr_default="true")
+                                    ndattr_default="false")
     ET.SubElement(NDAttributes_el, "attribute", name="NX_class",
                   source="constant", value="NXcollection", type="string")
+    ET.SubElement(NDAttributes_el, "attribute", name="NDArrayUniqueID",
+                  source="ndattribute", ndattribute="NDArrayUniqueID")
+    for attr in nd_attributes:
+        ET.SubElement(NDAttributes_el, "attribute", name=attr,
+                      source="ndattribute", ndattribute=attr)
     xml = et_to_string(root_el)
     return xml
 

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -6,7 +6,8 @@ from annotypes import add_call_types, Anno, TYPE_CHECKING
 from scanpointgenerator import CompoundGenerator, Dimension
 
 from malcolm.compat import et_to_string
-from malcolm.core import APartName, Future, Info, Block, PartRegistrar, BooleanMeta, Widget, config_tag
+from malcolm.core import APartName, Future, Info, Block, PartRegistrar, \
+    BooleanMeta, Widget, config_tag
 from malcolm.modules import builtin, scanning
 from ..infos import CalculatedNDAttributeDatasetInfo, DatasetType, \
     DatasetProducedInfo, NDArrayDatasetInfo, NDAttributeDatasetInfo, \
@@ -230,11 +231,6 @@ def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
                   source="ndattribute", ndattribute="NDArrayUniqueId")
     ET.SubElement(NDAttributes_el, "dataset", name="NDArrayTimeStamp",
                   source="ndattribute", ndattribute="NDArrayTimeStamp")
-    # All manually declared attributes have specific Dataset type, now go in /entry/$(name)/$(name)
-    # for dataset_info in [attr_set for attr_set in NDAttributeDatasetInfo.filter_values(part_info) if
-    #                      attr_set.type == AttributeDatasetType.MONITOR]:
-    #     ET.SubElement(NDAttributes_el, "dataset", name=dataset_info.name,
-    #                   source="ndattribute", ndattribute=dataset_info.attr)
 
     xml = et_to_string(root_el)
     return xml
@@ -251,7 +247,8 @@ def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
 class HDFWriterPart(builtin.parts.ChildPart):
     """Part for controlling an `hdf_writer_block` in a Device"""
 
-    def __init__(self, name, mri, runs_on_windows=False, write_all_nd_attributes=True):
+    def __init__(self, name, mri, runs_on_windows=False,
+                 write_all_nd_attributes=True):
         # type: (APartName, scanning.parts.AMri, APartRunsOnWindows, AWriteAllNDAttributes) -> None
         super(HDFWriterPart, self).__init__(name, mri)
         # Future for the start action
@@ -266,7 +263,9 @@ class HDFWriterPart(builtin.parts.ChildPart):
         # Hooks
         self.write_all_nd_attributes = BooleanMeta(
             "Toggles wheteher all NDAttributes are written to file, or only those specified in the dataset",
-            writeable=True, tags=[Widget.CHECKBOX.tag(), config_tag()]).create_attribute_model(write_all_nd_attributes)
+            writeable=True,
+            tags=[Widget.CHECKBOX.tag(), config_tag()]).create_attribute_model(
+            write_all_nd_attributes)
         self.register_hooked(scanning.hooks.ConfigureHook, self.configure)
         self.register_hooked((scanning.hooks.PostRunArmedHook,
                               scanning.hooks.SeekHook), self.seek)
@@ -285,7 +284,8 @@ class HDFWriterPart(builtin.parts.ChildPart):
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         super(HDFWriterPart, self).setup(registrar)
-        registrar.add_attribute_model("writeAllNdAttributes", self.write_all_nd_attributes,
+        registrar.add_attribute_model("writeAllNdAttributes",
+                                      self.write_all_nd_attributes,
                                       self.write_all_nd_attributes.set_value)
         # Tell the controller to expose some extra configure parameters
         registrar.report(scanning.hooks.ConfigureHook.create_info(
@@ -330,7 +330,8 @@ class HDFWriterPart(builtin.parts.ChildPart):
             fileName=formatName,
             fileTemplate="%s" + fileTemplate))
         futures += set_dimensions(child, generator)
-        xml = make_layout_xml(generator, part_info, self.write_all_nd_attributes.value)
+        xml = make_layout_xml(generator, part_info,
+                              self.write_all_nd_attributes.value)
         self.layout_filename = os.path.join(
             file_dir, "%s-layout.xml" % self.mri)
         with open(self.layout_filename, "w") as f:
@@ -354,7 +355,8 @@ class HDFWriterPart(builtin.parts.ChildPart):
                 steps_to_do, n_frames_between_flushes)
         layout_filename = self.layout_filename
         if self.runs_on_windows:
-            layout_filename = FilePathTranslatorInfo.translate_filepath(part_info, self.layout_filename)
+            layout_filename = FilePathTranslatorInfo.translate_filepath(
+                part_info, self.layout_filename)
         futures += child.put_attribute_values_async(dict(
             xml=layout_filename,
             flushDataPerNFrames=n_frames_between_flushes,

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -265,10 +265,9 @@ class HDFWriterPart(builtin.parts.ChildPart):
         self.layout_filename = None  # type: str
         self.runs_on_windows = runs_on_windows
         # Hooks
-        description = "Toggles whether all NDAttributes are written to " + \
-                      "file, or only those specified in the dataset"
         self.write_all_nd_attributes = BooleanMeta(
-            description,
+            "Toggles whether all NDAttributes are written to "
+            "file, or only those specified in the dataset",
             writeable=True,
             tags=[Widget.CHECKBOX.tag(), config_tag()]).create_attribute_model(
             write_all_nd_attributes)

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -211,7 +211,7 @@ def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
 
     # And then any other attribute sources of data
     for dataset_info in [attr_set for attr_set in NDAttributeDatasetInfo.filter_values(part_info) if
-                         attr_set.name.split('/')[0] != "NDAttributes"]:
+                         attr_set.type == AttributeDatasetType.DETECTOR]:
         # if we are a secondary source, use the same rank as the det
         attr_el = make_nxdata(dataset_info.name, dataset_info.rank,
                               entry_el, generator, link=True)
@@ -228,8 +228,8 @@ def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
                   source="ndattribute", ndattribute="NDArrayUniqueId")
 
     for dataset_info in [attr_set for attr_set in NDAttributeDatasetInfo.filter_values(part_info) if
-                         attr_set.name.split('/')[0] == "NDAttributes"]:
-        ET.SubElement(NDAttributes_el, "dataset", name=dataset_info.name.split('/')[1],
+                         attr_set.type == AttributeDatasetType.MONITOR]:
+        ET.SubElement(NDAttributes_el, "dataset", name=dataset_info.name,
                       source="ndattribute", ndattribute=dataset_info.attr)
 
     xml = et_to_string(root_el)

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -6,8 +6,8 @@ from annotypes import Anno, add_call_types
 from malcolm.compat import et_to_string
 from malcolm.core import APartName
 from malcolm.modules import builtin, scanning
-from ..infos import CalculatedNDAttributeDatasetInfo
-from ..util import StatisticsName
+from ..infos import CalculatedNDAttributeDatasetInfo, FilePathTranslatorInfo
+from ..util import StatisticsName, APartRunsOnWindows
 
 with Anno("Which statistic to capture"):
     AStatisticsName = StatisticsName
@@ -20,12 +20,13 @@ with Anno("Directory to write data to"):
 class StatsPluginPart(builtin.parts.ChildPart):
     """Part for controlling a `stats_plugin_block` in a Device"""
 
-    def __init__(self, name, mri, statistic=StatisticsName.SUM):
-        # type: (APartName, builtin.parts.AMri, AStatisticsName) -> None
+    def __init__(self, name, mri, statistic=StatisticsName.SUM, runs_on_windows=False):
+        # type: (APartName, builtin.parts.AMri, AStatisticsName, APartRunsOnWindows) -> None
         super(StatsPluginPart, self).__init__(name, mri)
         self.statistic = statistic
         # The NDAttributes file we write to say what to capture
         self.attributes_filename = None  # type: str
+        self.runs_on_windows = runs_on_windows
         # Hooks
         self.register_hooked(scanning.hooks.ReportStatusHook,
                              self.report_status)
@@ -56,8 +57,8 @@ class StatsPluginPart(builtin.parts.ChildPart):
     # Allow CamelCase as these parameters will be serialized
     # noinspection PyPep8Naming
     @add_call_types
-    def configure(self, context, fileDir):
-        # type: (scanning.hooks.AContext, AFileDir) -> None
+    def configure(self, context, part_info, fileDir):
+        # type: (scanning.hooks.AContext, scanning.hooks.APartInfo, AFileDir) -> None
         child = context.block_view(self.mri)
         fs = child.put_attribute_values_async(dict(
             enableCallbacks=True,
@@ -67,8 +68,12 @@ class StatsPluginPart(builtin.parts.ChildPart):
             fileDir, "%s-attributes.xml" % self.mri)
         with open(self.attributes_filename, "w") as f:
             f.write(xml)
+        attributes_filename = self.attributes_filename
+        if self.runs_on_windows:
+            translator = FilePathTranslatorInfo.filter_single_value(part_info)
+            attributes_filename = translator.translate_filepath(self.attributes_filename)
         fs.append(
-            child.attributesFile.put_value_async(self.attributes_filename))
+            child.attributesFile.put_value_async(attributes_filename))
         context.wait_all_futures(fs)
 
     @add_call_types

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -22,9 +22,9 @@ class StatsPluginPart(builtin.parts.ChildPart):
     """Part for controlling a `stats_plugin_block` in a Device"""
 
     def __init__(self,
-                 name,                          # type: APartName,
-                 mri,                           # type: builtin.parts.AMri,
-                 statistic=StatisticsName.SUM,  # type: AStatsName,
+                 name,                          # type: APartName
+                 mri,                           # type: builtin.parts.AMri
+                 statistic=StatisticsName.SUM,  # type: AStatsName
                  runs_on_windows=False,         # type: APartRunsOnWindows
                  ):
         # type: (...) -> None

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -70,8 +70,7 @@ class StatsPluginPart(builtin.parts.ChildPart):
             f.write(xml)
         attributes_filename = self.attributes_filename
         if self.runs_on_windows:
-            translator = FilePathTranslatorInfo.filter_single_value(part_info)
-            attributes_filename = translator.translate_filepath(self.attributes_filename)
+            attributes_filename = FilePathTranslatorInfo.translate_filepath(part_info, self.attributes_filename)
         fs.append(
             child.attributesFile.put_value_async(attributes_filename))
         context.wait_all_futures(fs)

--- a/malcolm/modules/ADCore/util.py
+++ b/malcolm/modules/ADCore/util.py
@@ -9,6 +9,8 @@ from malcolm.modules import scanning
 if TYPE_CHECKING:
     from typing import List, Any
 
+with Anno("Is the IOC this part connects to running on Windows?"):
+    APartRunsOnWindows = bool
 
 class AttributeDatasetType(Enum):
     DETECTOR = "detector"

--- a/malcolm/modules/ADCore/util.py
+++ b/malcolm/modules/ADCore/util.py
@@ -35,7 +35,10 @@ class StatisticsName(Enum):
     SUM = "TOTAL"  # Sum of all elements
     NET = "NET"  # Sum of all elements not in background region
 
-
+with Anno("PV names"):
+    APvNameArray = Array[str]
+with Anno("PV descriptions"):
+    ADescriptionArray = Array[str]
 with Anno("Dataset names"):
     ANameArray = Array[str]
 with Anno("Filenames of HDF files relative to fileDir"):
@@ -49,6 +52,8 @@ with Anno("Dataset paths within HDF files"):
 with Anno("UniqueID array paths within HDF files"):
     AUniqueIDArray = Array[str]
 UNameArray = Union[ANameArray, Sequence[str]]
+UPvNameArray = Union[APvNameArray, Sequence[str]]
+UDescriptionArray = Union[ADescriptionArray, Sequence[str]]
 UFilenameArray = Union[AFilenameArray, Sequence[str]]
 UTypeArray = Union[ATypeArray, Sequence[DatasetType]]
 URankArray = Union[ARankArray, Sequence[np.int32]]
@@ -74,6 +79,20 @@ class DatasetTable(Table):
         self.rank = ARankArray(rank)
         self.path = APathArray(path)
         self.uniqueid = AUniqueIDArray(uniqueid)
+
+
+class PVSetTable(Table):
+    # This will be serialized so we need type to be called that
+    # noinspection PyShadowingBuiltins
+    def __init__(self,
+                 name,  # type: UNameArray
+                 pv,    # type: UPvNameArray
+                 description, # type: UDescriptionArray
+                 ):
+        # type: (...) -> None
+        self.name = ANameArray(name)
+        self.pv = APvNameArray(pv)
+        self.description = ADescriptionArray(description)
 
 
 class ADBaseActions(object):

--- a/malcolm/modules/ADCore/util.py
+++ b/malcolm/modules/ADCore/util.py
@@ -50,7 +50,8 @@ class StatisticsName(Enum):
 
 with Anno("Is the IOC this part connects to running on Windows?"):
     APartRunsOnWindows = bool
-with Anno("source ID for attribute (PV name for PVAttribute, asyn param name for paramAttribute)"):
+with Anno("source ID for attribute (PV name for PVAttribute," +
+          "asyn param name for paramAttribute)"):
     ASourceIdArray = Array[str]
 with Anno("PV descriptions"):
     ADescriptionArray = Array[str]
@@ -109,12 +110,12 @@ class ExtraAttributesTable(Table):
     # Allow CamelCase as arguments will be serialized
     # noinspection PyPep8Naming
     def __init__(self,
-                 name,          # type: UNameArray
-                 sourceId,      # type: USourceIdArray
-                 description,   # type: UDescriptionArray
-                 sourceType,    # type: USourceTypeArray
-                 dataType,      # type: UDataTypeArray
-                 datasetType,   # type: UAttributeTypeArray
+                 name,  # type: UNameArray
+                 sourceId,  # type: USourceIdArray
+                 description,  # type: UDescriptionArray
+                 sourceType,  # type: USourceTypeArray
+                 dataType,  # type: UDataTypeArray
+                 datasetType,  # type: UAttributeTypeArray
                  ):
         # type: (...) -> None
         self.name = ANameArray(name)

--- a/malcolm/modules/ADCore/util.py
+++ b/malcolm/modules/ADCore/util.py
@@ -90,7 +90,11 @@ AttrSetTableElements = {
         tags=[Widget.TEXTINPUT.tag()], writeable=True),
     "description": StringArrayMeta("description of attribute", tags=[Widget.TEXTINPUT.tag()], writeable=True),
     "sourceType": ChoiceArrayMeta("source of data to be added to dataset", tags=[Widget.COMBO.tag()],
-                                  choices=["NDAttribute", "PVAttribute"], writeable=True)
+                                  choices=["PVAttribute", "paramAttribute"], writeable=True),
+    "dataType": ChoiceArrayMeta("type of data provided by source", tags=[Widget.COMBO.tag()],
+                                  choices=["INT", "DOUBLE", "STRING", "DBR_NATIVE"], writeable=True),
+    "datasetType": ChoiceArrayMeta("type of dataset", tags=[Widget.COMBO.tag()],
+                                  choices=["monitor", "detector", "position"], writeable=True)
 }
 
 

--- a/malcolm/modules/ADCore/util.py
+++ b/malcolm/modules/ADCore/util.py
@@ -2,7 +2,8 @@ from annotypes import Anno, Array, Union, Sequence, TYPE_CHECKING
 from enum import Enum
 import numpy as np
 
-from malcolm.core import Table, Future, Context, PartRegistrar, DEFAULT_TIMEOUT
+from malcolm.core import Table, Future, Context, PartRegistrar, DEFAULT_TIMEOUT, StringArrayMeta, ChoiceArrayMeta, \
+    Widget
 from malcolm.modules import scanning
 
 if TYPE_CHECKING:
@@ -34,6 +35,7 @@ class StatisticsName(Enum):
     SIGMA = "SIGMA_VALUE"  # Sigma of all elements
     SUM = "TOTAL"  # Sum of all elements
     NET = "NET"  # Sum of all elements not in background region
+
 
 with Anno("PV names"):
     APvNameArray = Array[str]
@@ -81,13 +83,24 @@ class DatasetTable(Table):
         self.uniqueid = AUniqueIDArray(uniqueid)
 
 
+AttrSetTableElements = {
+    "name": StringArrayMeta("name to give to NDAttribute in dataset", tags=[Widget.TEXTINPUT.tag()], writeable=True),
+    "sourceId": StringArrayMeta(
+        "reference to give to attribute in dataset (NDAttribute name if existing NDAttribute, PV name if PVAttribute)",
+        tags=[Widget.TEXTINPUT.tag()], writeable=True),
+    "description": StringArrayMeta("description of attribute", tags=[Widget.TEXTINPUT.tag()], writeable=True),
+    "sourceType": ChoiceArrayMeta("source of data to be added to dataset", tags=[Widget.COMBO.tag()],
+                                  choices=["NDAttribute", "PVAttribute"], writeable=True)
+}
+
+
 class PVSetTable(Table):
     # This will be serialized so we need type to be called that
     # noinspection PyShadowingBuiltins
     def __init__(self,
                  name,  # type: UNameArray
-                 pv,    # type: UPvNameArray
-                 description, # type: UDescriptionArray
+                 pv,  # type: UPvNameArray
+                 description,  # type: UDescriptionArray
                  ):
         # type: (...) -> None
         self.name = ANameArray(name)

--- a/malcolm/modules/xmap/blocks/xmap_driver_block.yaml
+++ b/malcolm/modules/xmap/blocks/xmap_driver_block.yaml
@@ -118,3 +118,7 @@
     pv: $(prefix):InputLogicPolarity
     rbv_suffix: _RBV
 
+- ca.parts.CACharArrayPart:
+    name: attributesFile
+    description: Filename for NDAttributes
+    pv: $(prefix):TX:NDAttributesFile

--- a/malcolm/modules/xmap/blocks/xmap_runnable_block.yaml
+++ b/malcolm/modules/xmap/blocks/xmap_runnable_block.yaml
@@ -37,5 +37,5 @@
 
 - ADCore.parts.FilepathTranslatorPart:
     name: WINPATH
-    default_windows_drive_letter: T
-    default_path_prefix: /dls
+    initial_windows_drive_letter: T
+    initial_path_prefix: /dls

--- a/malcolm/modules/xmap/blocks/xmap_runnable_block.yaml
+++ b/malcolm/modules/xmap/blocks/xmap_runnable_block.yaml
@@ -21,6 +21,7 @@
 - xmap.parts.XmapDriverPart:
     name: DRV
     mri: $(mri_prefix):DRV
+    runs_on_windows: true
 
 - ADCore.blocks.stats_plugin_block:
     mri: $(mri_prefix):STAT
@@ -33,3 +34,8 @@
 - ADCore.includes.filewriting_collection:
     pv_prefix: $(pv_prefix)
     mri_prefix: $(mri_prefix)
+
+- ADCore.parts.FilepathTranslatorPart:
+    name: WINPATH
+    default_windows_drive_letter: T
+    default_path_prefix: /dls

--- a/malcolm/modules/xmap/parts/xmapdriverpart.py
+++ b/malcolm/modules/xmap/parts/xmapdriverpart.py
@@ -35,4 +35,5 @@ class XmapDriverPart(ADCore.parts.DetectorDriverPart):
             dxp2MaxEnergy=4.096,
             dxp3MaxEnergy=4.096,
             dxp4MaxEnergy=4.096,
-            inputLogicPolarity="Normal")
+            inputLogicPolarity="Normal",
+            fileDir=kwargs["fileDir"])

--- a/malcolm/modules/xmap/parts/xmapdriverpart.py
+++ b/malcolm/modules/xmap/parts/xmapdriverpart.py
@@ -10,7 +10,8 @@ from malcolm.modules import ADCore, scanning, builtin
     "inputLogicPolarity")
 class XmapDriverPart(ADCore.parts.DetectorDriverPart):
     """Part for using xmap_driver_block in a scan"""
-
+    # Allow CamelCase as fileDir parameter will be serialized
+    # noinspection PyPep8Naming
     @add_call_types
     def configure(self,
                   context,  # type: scanning.hooks.AContext
@@ -18,11 +19,13 @@ class XmapDriverPart(ADCore.parts.DetectorDriverPart):
                   steps_to_do,  # type: scanning.hooks.AStepsToDo
                   part_info,  # type: scanning.hooks.APartInfo
                   generator,  # type: scanning.hooks.AGenerator
+                  fileDir,  # type: ADCore.parts.AFileDir
                   **kwargs  # type: **Any
                   ):
         # type: (...) -> None
         super(XmapDriverPart, self).configure(
             context, completed_steps, steps_to_do, part_info, generator,
+            fileDir=fileDir,
             collectMode="MCA mapping",
             pixelAdvanceMode="Gate",
             presetMode="No preset",
@@ -35,5 +38,4 @@ class XmapDriverPart(ADCore.parts.DetectorDriverPart):
             dxp2MaxEnergy=4.096,
             dxp3MaxEnergy=4.096,
             dxp4MaxEnergy=4.096,
-            inputLogicPolarity="Normal",
-            fileDir=kwargs["fileDir"])
+            inputLogicPolarity="Normal")

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,7 @@ mock>=2.0.0
 nose>=1.3.0
 coverage>=3.7.1
 tornado>=4.1,<5.0
-scanpointgenerator>=2.1.0
+scanpointgenerator==2.1.1
 cothread==2.14
 enum34
 ruamel.yaml

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,5 +11,5 @@ pytest>=3.2.0
 pytest-cov<=2.6.0
 h5py>=2.8.0
 vdsgen>=0.3
-annotypes>=0.9
+annotypes==0.9
 p4p>=3.0.0

--- a/tests/test_modules/test_ADAndor/test_andordriverpart.py
+++ b/tests/test_modules/test_ADAndor/test_andordriverpart.py
@@ -37,7 +37,7 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         # both set to 0.1
         self.set_attributes(self.child, exposure=0.1, acquirePeriod=0.105)
         self.o.configure(
-            self.context, completed_steps, steps_to_do, {}, generator=generator)
+            self.context, completed_steps, steps_to_do, {}, generator=generator, fileDir="/tmp")
         assert self.child.handled_requests.mock_calls == [
             call.put('exposure', 0.1),
             call.put('acquirePeriod', 0.1),
@@ -49,4 +49,5 @@ class TestAndorDetectorDriverPart(ChildTestCase):
             call.put('numImages', 6000000),
             call.put('acquirePeriod', 0.1 - 5e-6),
             call.post('start'),
-            call.when_values_matches('acquiring', True, None, 10.0, None)]
+            call.when_values_matches('acquiring', True, None, 10.0, None),
+            call.put('attributesFile', '/tmp/mri-attributes.xml')]

--- a/tests/test_modules/test_ADAndor/test_andordriverpart.py
+++ b/tests/test_modules/test_ADAndor/test_andordriverpart.py
@@ -49,5 +49,4 @@ class TestAndorDetectorDriverPart(ChildTestCase):
             call.put('numImages', 6000000),
             call.put('acquirePeriod', 0.1 - 5e-6),
             call.post('start'),
-            call.when_values_matches('acquiring', True, None, 10.0, None),
-            call.put('attributesFile', '/tmp/mri-attributes.xml')]
+            call.when_values_matches('acquiring', True, None, 10.0, None)]

--- a/tests/test_modules/test_ADCore/test_detectordriverpart.py
+++ b/tests/test_modules/test_ADCore/test_detectordriverpart.py
@@ -34,7 +34,8 @@ class TestDetectorDriverPart(ChildTestCase):
 
     def test_report(self):
         info = self.o.report_status()
-        assert info.rank == 2
+        assert len(info) == 1
+        assert info[0].rank == 2
 
     def test_configure(self):
         xs = LineGenerator("x", "mm", 0.0, 0.5, 3, alternate=True)
@@ -46,7 +47,7 @@ class TestDetectorDriverPart(ChildTestCase):
         part_info = dict(anyname=[ExposureDeadtimeInfo(0.01, 1000)])
         self.set_attributes(self.child, triggerMode="Internal")
         self.o.configure(
-            self.context, completed_steps, steps_to_do, part_info, generator)
+            self.context, completed_steps, steps_to_do, part_info, generator, fileDir="/tmp")
         assert self.child.handled_requests.mock_calls == [
             call.put('arrayCallbacks', True),
             call.put('arrayCounter', 0),
@@ -54,6 +55,7 @@ class TestDetectorDriverPart(ChildTestCase):
             call.put('imageMode', 'Multiple'),
             call.put('numImages', 6),
             call.put('acquirePeriod', 0.1 - 0.0001),
+            call.put('attributesFile', '/tmp/mri-attributes.xml'),
         ]
         assert not self.o.is_hardware_triggered
 

--- a/tests/test_modules/test_ADCore/test_hdfwriterpart.py
+++ b/tests/test_modules/test_ADCore/test_hdfwriterpart.py
@@ -7,10 +7,91 @@ from malcolm.core import Context, Process, Future
 from malcolm.modules.ADCore.blocks import hdf_writer_block
 from malcolm.modules.ADCore.parts import HDFWriterPart
 from malcolm.modules.ADCore.infos import NDArrayDatasetInfo, \
-    CalculatedNDAttributeDatasetInfo, NDAttributeDatasetInfo
+    CalculatedNDAttributeDatasetInfo, NDAttributeDatasetInfo, FilePathTranslatorInfo
 from malcolm.modules.ADCore.util import AttributeDatasetType, DatasetType
 from malcolm.modules.scanning.controllers import RunnableController
 from malcolm.testutil import ChildTestCase
+
+
+expected_xml = """<?xml version="1.0" ?>
+<hdf5_layout auto_ndattr_default="false">
+<group name="entry">
+<attribute name="NX_class" source="constant" type="string" value="NXentry" />
+<group name="detector">
+<attribute name="signal" source="constant" type="string" value="detector" />
+<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
+<attribute name="NX_class" source="constant" type="string" value="NXdata" />
+<attribute name="energy_set_indices" source="constant" type="string" value="0" />
+<dataset name="energy_set" source="constant" type="float" value="13,15.2">
+<attribute name="units" source="constant" type="string" value="kEv" />
+</dataset>
+<attribute name="x_set_indices" source="constant" type="string" value="1" />
+<dataset name="x_set" source="constant" type="float" value="0.473264298891,-1.28806365331,-1.11933765723,0.721339144968,2.26130106714,2.3717213098,1.08574712174,-0.863941392256,-2.59791589857,-3.46951769442,-3.22399679412,-1.98374931946,-0.132541097885,1.83482458567,3.45008680308,4.36998121172,4.42670524204,3.63379270355,2.15784413199,0.269311496406">
+<attribute name="units" source="constant" type="string" value="mm" />
+</dataset>
+<attribute name="y_set_indices" source="constant" type="string" value="1" />
+<dataset name="y_set" source="constant" type="float" value="-0.64237113553,-0.500750778455,1.38930992616,1.98393756064,0.784917470231,-1.17377831157,-2.66405897615,-2.9669684623,-2.01825893141,-0.24129368636,1.72477821509,3.27215424484,3.98722048131,3.71781556747,2.5610299588,0.799047653518,-1.18858453138,-3.01284626565,-4.34725663835,-4.9755042398">
+<attribute name="units" source="constant" type="string" value="mm" />
+</dataset>
+<dataset det_default="true" name="detector" source="detector">
+<attribute name="NX_class" source="constant" type="string" value="SDS" />
+</dataset>
+</group>
+<group name="sum">
+<attribute name="signal" source="constant" type="string" value="sum" />
+<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
+<attribute name="NX_class" source="constant" type="string" value="NXdata" />
+<attribute name="energy_set_indices" source="constant" type="string" value="0" />
+<hardlink name="energy_set" target="/entry/detector/energy_set" />
+<attribute name="x_set_indices" source="constant" type="string" value="1" />
+<hardlink name="x_set" target="/entry/detector/x_set" />
+<attribute name="y_set_indices" source="constant" type="string" value="1" />
+<hardlink name="y_set" target="/entry/detector/y_set" />
+<dataset name="sum" ndattribute="StatsTotal" source="ndattribute" />
+</group>
+<group name="I0">
+<attribute name="signal" source="constant" type="string" value="I0" />
+<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
+<attribute name="NX_class" source="constant" type="string" value="NXdata" />
+<attribute name="energy_set_indices" source="constant" type="string" value="0" />
+<hardlink name="energy_set" target="/entry/detector/energy_set" />
+<attribute name="x_set_indices" source="constant" type="string" value="1" />
+<hardlink name="x_set" target="/entry/detector/x_set" />
+<attribute name="y_set_indices" source="constant" type="string" value="1" />
+<hardlink name="y_set" target="/entry/detector/y_set" />
+<dataset name="I0" ndattribute="COUNTER1.COUNTER" source="ndattribute" />
+</group>
+<group name="It">
+<attribute name="signal" source="constant" type="string" value="It" />
+<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
+<attribute name="NX_class" source="constant" type="string" value="NXdata" />
+<attribute name="energy_set_indices" source="constant" type="string" value="0" />
+<hardlink name="energy_set" target="/entry/detector/energy_set" />
+<attribute name="x_set_indices" source="constant" type="string" value="1" />
+<hardlink name="x_set" target="/entry/detector/x_set" />
+<attribute name="y_set_indices" source="constant" type="string" value="1" />
+<hardlink name="y_set" target="/entry/detector/y_set" />
+<dataset name="It" ndattribute="COUNTER2.COUNTER" source="ndattribute" />
+</group>
+<group name="t1x">
+<attribute name="signal" source="constant" type="string" value="t1x" />
+<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
+<attribute name="NX_class" source="constant" type="string" value="NXdata" />
+<attribute name="energy_set_indices" source="constant" type="string" value="0" />
+<hardlink name="energy_set" target="/entry/detector/energy_set" />
+<attribute name="x_set_indices" source="constant" type="string" value="1" />
+<hardlink name="x_set" target="/entry/detector/x_set" />
+<attribute name="y_set_indices" source="constant" type="string" value="1" />
+<hardlink name="y_set" target="/entry/detector/y_set" />
+<dataset name="t1x" ndattribute="INENC1.VAL" source="ndattribute" />
+</group>
+<group name="NDAttributes" ndattr_default="false">
+<attribute name="NX_class" source="constant" type="string" value="NXcollection" />
+<dataset name="NDArrayUniqueId" ndattribute="NDArrayUniqueId" source="ndattribute" />
+<dataset name="NDArrayTimeStamp" ndattribute="NDArrayTimeStamp" source="ndattribute" />
+</group>
+</group>
+</hdf5_layout>"""
 
 
 class TestHDFWriterPart(ChildTestCase):
@@ -22,14 +103,14 @@ class TestHDFWriterPart(ChildTestCase):
         self.child = self.create_child_block(
             hdf_writer_block, self.process,
             mri="BLOCK-HDF5", prefix="prefix")
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
-        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
-        self.process.start()
 
     def tearDown(self):
         self.process.stop(2)
 
     def test_init(self):
+        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
         c = RunnableController("mri", "/tmp")
         c.add_part(self.o)
         self.process.add_controller(c)
@@ -38,6 +119,9 @@ class TestHDFWriterPart(ChildTestCase):
             'generator', 'fileDir', 'axesToMove', 'formatName', 'fileTemplate']
 
     def test_configure(self):
+        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
         energy = LineGenerator("energy", "kEv", 13.0, 15.2, 2)
         spiral = SpiralGenerator(
             ["x", "y"], ["mm", "mm"], [0., 0.], 5., scale=2.0)
@@ -161,88 +245,146 @@ class TestHDFWriterPart(ChildTestCase):
             call.put('xml', expected_xml_filename),
             call.put('numCapture', 0),
             call.post('start')]
-        expected_xml = """<?xml version="1.0" ?>
-<hdf5_layout>
-<group name="entry">
-<attribute name="NX_class" source="constant" type="string" value="NXentry" />
-<group name="detector">
-<attribute name="signal" source="constant" type="string" value="detector" />
-<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
-<attribute name="NX_class" source="constant" type="string" value="NXdata" />
-<attribute name="energy_set_indices" source="constant" type="string" value="0" />
-<dataset name="energy_set" source="constant" type="float" value="13,15.2">
-<attribute name="units" source="constant" type="string" value="kEv" />
-</dataset>
-<attribute name="x_set_indices" source="constant" type="string" value="1" />
-<dataset name="x_set" source="constant" type="float" value="0.473264298891,-1.28806365331,-1.11933765723,0.721339144968,2.26130106714,2.3717213098,1.08574712174,-0.863941392256,-2.59791589857,-3.46951769442,-3.22399679412,-1.98374931946,-0.132541097885,1.83482458567,3.45008680308,4.36998121172,4.42670524204,3.63379270355,2.15784413199,0.269311496406">
-<attribute name="units" source="constant" type="string" value="mm" />
-</dataset>
-<attribute name="y_set_indices" source="constant" type="string" value="1" />
-<dataset name="y_set" source="constant" type="float" value="-0.64237113553,-0.500750778455,1.38930992616,1.98393756064,0.784917470231,-1.17377831157,-2.66405897615,-2.9669684623,-2.01825893141,-0.24129368636,1.72477821509,3.27215424484,3.98722048131,3.71781556747,2.5610299588,0.799047653518,-1.18858453138,-3.01284626565,-4.34725663835,-4.9755042398">
-<attribute name="units" source="constant" type="string" value="mm" />
-</dataset>
-<dataset det_default="true" name="detector" source="detector">
-<attribute name="NX_class" source="constant" type="string" value="SDS" />
-</dataset>
-</group>
-<group name="sum">
-<attribute name="signal" source="constant" type="string" value="sum" />
-<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
-<attribute name="NX_class" source="constant" type="string" value="NXdata" />
-<attribute name="energy_set_indices" source="constant" type="string" value="0" />
-<hardlink name="energy_set" target="/entry/detector/energy_set" />
-<attribute name="x_set_indices" source="constant" type="string" value="1" />
-<hardlink name="x_set" target="/entry/detector/x_set" />
-<attribute name="y_set_indices" source="constant" type="string" value="1" />
-<hardlink name="y_set" target="/entry/detector/y_set" />
-<dataset name="sum" ndattribute="StatsTotal" source="ndattribute" />
-</group>
-<group name="I0">
-<attribute name="signal" source="constant" type="string" value="I0" />
-<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
-<attribute name="NX_class" source="constant" type="string" value="NXdata" />
-<attribute name="energy_set_indices" source="constant" type="string" value="0" />
-<hardlink name="energy_set" target="/entry/detector/energy_set" />
-<attribute name="x_set_indices" source="constant" type="string" value="1" />
-<hardlink name="x_set" target="/entry/detector/x_set" />
-<attribute name="y_set_indices" source="constant" type="string" value="1" />
-<hardlink name="y_set" target="/entry/detector/y_set" />
-<dataset name="I0" ndattribute="COUNTER1.COUNTER" source="ndattribute" />
-</group>
-<group name="It">
-<attribute name="signal" source="constant" type="string" value="It" />
-<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
-<attribute name="NX_class" source="constant" type="string" value="NXdata" />
-<attribute name="energy_set_indices" source="constant" type="string" value="0" />
-<hardlink name="energy_set" target="/entry/detector/energy_set" />
-<attribute name="x_set_indices" source="constant" type="string" value="1" />
-<hardlink name="x_set" target="/entry/detector/x_set" />
-<attribute name="y_set_indices" source="constant" type="string" value="1" />
-<hardlink name="y_set" target="/entry/detector/y_set" />
-<dataset name="It" ndattribute="COUNTER2.COUNTER" source="ndattribute" />
-</group>
-<group name="t1x">
-<attribute name="signal" source="constant" type="string" value="t1x" />
-<attribute name="axes" source="constant" type="string" value="energy_set,.,.,." />
-<attribute name="NX_class" source="constant" type="string" value="NXdata" />
-<attribute name="energy_set_indices" source="constant" type="string" value="0" />
-<hardlink name="energy_set" target="/entry/detector/energy_set" />
-<attribute name="x_set_indices" source="constant" type="string" value="1" />
-<hardlink name="x_set" target="/entry/detector/x_set" />
-<attribute name="y_set_indices" source="constant" type="string" value="1" />
-<hardlink name="y_set" target="/entry/detector/y_set" />
-<dataset name="t1x" ndattribute="INENC1.VAL" source="ndattribute" />
-</group>
-<group name="NDAttributes" ndattr_default="true">
-<attribute name="NX_class" source="constant" type="string" value="NXcollection" />
-</group>
-</group>
-</hdf5_layout>"""
         with open(expected_xml_filename) as f:
             actual_xml = f.read().replace(">", ">\n")
         assert actual_xml.splitlines() == expected_xml.splitlines()
 
+    def test_configure_windows(self):
+        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5", runs_on_windows=True)
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
+        energy = LineGenerator("energy", "kEv", 13.0, 15.2, 2)
+        spiral = SpiralGenerator(
+            ["x", "y"], ["mm", "mm"], [0., 0.], 5., scale=2.0)
+        generator = CompoundGenerator([energy, spiral], [], [], 0.1)
+        generator.prepare()
+        fileDir = "/tmp"
+        formatName = "xspress3"
+        fileTemplate = "thing-%s.h5"
+        completed_steps = 0
+        steps_to_do = 38
+        part_info = {
+            "DET": [NDArrayDatasetInfo(2), FilePathTranslatorInfo("Y", "/tmp")],
+            "PANDA": [
+                NDAttributeDatasetInfo(
+                    "I0", AttributeDatasetType.DETECTOR, "COUNTER1.COUNTER", 2),
+                NDAttributeDatasetInfo(
+                    "It", AttributeDatasetType.MONITOR, "COUNTER2.COUNTER", 2),
+                NDAttributeDatasetInfo(
+                    "t1x", AttributeDatasetType.POSITION, "INENC1.VAL", 2)],
+            "STAT": [CalculatedNDAttributeDatasetInfo("sum", "StatsTotal")],
+        }
+        infos = self.o.configure(
+            self.context, completed_steps, steps_to_do, part_info, generator,
+            fileDir, formatName, fileTemplate)
+        assert len(infos) == 8
+        assert infos[0].name == "xspress3.data"
+        assert infos[0].filename == "thing-xspress3.h5"
+        assert infos[0].type == DatasetType.PRIMARY
+        assert infos[0].rank == 4
+        assert infos[0].path == "/entry/detector/detector"
+        assert infos[0].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
+
+        assert infos[1].name == "xspress3.sum"
+        assert infos[1].filename == "thing-xspress3.h5"
+        assert infos[1].type == DatasetType.SECONDARY
+        assert infos[1].rank == 4
+        assert infos[1].path == "/entry/sum/sum"
+        assert infos[1].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
+
+        assert infos[2].name == "I0.data"
+        assert infos[2].filename == "thing-xspress3.h5"
+        assert infos[2].type == DatasetType.PRIMARY
+        assert infos[2].rank == 4
+        assert infos[2].path == "/entry/I0/I0"
+        assert infos[2].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
+
+        assert infos[3].name == "It.data"
+        assert infos[3].filename == "thing-xspress3.h5"
+        assert infos[3].type == DatasetType.MONITOR
+        assert infos[3].rank == 4
+        assert infos[3].path == "/entry/It/It"
+        assert infos[3].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
+
+        assert infos[4].name == "t1x.value"
+        assert infos[4].filename == "thing-xspress3.h5"
+        assert infos[4].type == DatasetType.POSITION_VALUE
+        assert infos[4].rank == 4
+        assert infos[4].path == "/entry/t1x/t1x"
+        assert infos[4].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
+
+        assert infos[5].name == "energy.value_set"
+        assert infos[5].filename == "thing-xspress3.h5"
+        assert infos[5].type == DatasetType.POSITION_SET
+        assert infos[5].rank == 1
+        assert infos[5].path == "/entry/detector/energy_set"
+        assert infos[5].uniqueid == ""
+
+        assert infos[6].name == "x.value_set"
+        assert infos[6].filename == "thing-xspress3.h5"
+        assert infos[6].type == DatasetType.POSITION_SET
+        assert infos[6].rank == 1
+        assert infos[6].path == "/entry/detector/x_set"
+        assert infos[6].uniqueid == ""
+
+        assert infos[7].name == "y.value_set"
+        assert infos[7].filename == "thing-xspress3.h5"
+        assert infos[7].type == DatasetType.POSITION_SET
+        assert infos[7].rank == 1
+        assert infos[7].path == "/entry/detector/y_set"
+        assert infos[7].uniqueid == ""
+
+        expected_xml_filename_unix = "/tmp/BLOCK-HDF5-layout.xml"
+        expected_xml_filename_windows = "Y:\\BLOCK-HDF5-layout.xml"
+        # Wait for the start_future so the post gets through to our child
+        # even on non-cothread systems
+        self.o.start_future.result(timeout=1)
+        assert self.child.handled_requests.mock_calls == [
+            call.put('positionMode', True),
+            call.put('arrayCounter', 0),
+            call.put('dimAttDatasets', True),
+            call.put('enableCallbacks', True),
+            call.put('fileName', 'xspress3'),
+            call.put('filePath', '/tmp/'),
+            call.put('fileTemplate', '%sthing-%s.h5'),
+            call.put('fileWriteMode', 'Stream'),
+            call.put('lazyOpen', True),
+            call.put('positionMode', True),
+            call.put('swmrMode', True),
+            call.put('extraDimSize3', 1),
+            call.put('extraDimSize4', 1),
+            call.put('extraDimSize5', 1),
+            call.put('extraDimSize6', 1),
+            call.put('extraDimSize7', 1),
+            call.put('extraDimSize8', 1),
+            call.put('extraDimSize9', 1),
+            call.put('extraDimSizeN', 20),
+            call.put('extraDimSizeX', 2),
+            call.put('extraDimSizeY', 1),
+            call.put('numExtraDims', 1),
+            call.put('posNameDim3', ''),
+            call.put('posNameDim4', ''),
+            call.put('posNameDim5', ''),
+            call.put('posNameDim6', ''),
+            call.put('posNameDim7', ''),
+            call.put('posNameDim8', ''),
+            call.put('posNameDim9', ''),
+            call.put('posNameDimN', 'd1'),
+            call.put('posNameDimX', 'd0'),
+            call.put('posNameDimY', ''),
+            call.put('flushAttrPerNFrames', 10.0),
+            call.put('flushDataPerNFrames', 10.0),
+            call.put('xml', expected_xml_filename_windows),
+            call.put('numCapture', 0),
+            call.post('start')]
+        with open(expected_xml_filename_unix) as f:
+            actual_xml = f.read().replace(">", ">\n")
+        assert actual_xml.splitlines() == expected_xml.splitlines()
+
     def test_run(self):
+        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
         self.o.done_when_reaches = 38
         self.o.completed_offset = 0
         # Say that we're getting the first frame
@@ -258,6 +400,9 @@ class TestHDFWriterPart(ChildTestCase):
         assert self.o.registrar.report.call_args_list[0][0][0].steps == 38
 
     def test_seek(self):
+        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
         self.o.done_when_reaches = 10
         completed_steps = 4
         steps_to_do = 3
@@ -267,6 +412,9 @@ class TestHDFWriterPart(ChildTestCase):
         assert self.o.done_when_reaches == 13
 
     def test_post_run_ready(self):
+        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
         # Say that we've returned from start
         self.o.start_future = Future(None)
         self.o.start_future.set_result(None)

--- a/tests/test_modules/test_ADCore/test_statspluginpart.py
+++ b/tests/test_modules/test_ADCore/test_statspluginpart.py
@@ -1,8 +1,9 @@
-from mock import call, MagicMock, ANY
+from mock import call
 
 from malcolm.core import Context, Process
 from malcolm.modules.ADCore.blocks import stats_plugin_block
 from malcolm.modules.ADCore.parts import StatsPluginPart
+from malcolm.modules.ADCore.infos import FilePathTranslatorInfo
 from malcolm.testutil import ChildTestCase
 
 
@@ -14,22 +15,26 @@ class TestStatsPluginPart(ChildTestCase):
         self.child = self.create_child_block(
             stats_plugin_block, self.process,
             mri="BLOCK-STAT", prefix="prefix")
-        self.o = StatsPluginPart(name="m", mri="BLOCK-STAT")
-        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
-        self.process.start()
 
     def tearDown(self):
         self.process.stop(timeout=2)
 
     def test_report_info(self):
+        self.o = StatsPluginPart(name="m", mri="BLOCK-STAT")
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
         infos = self.o.report_status()
         assert len(infos) == 1
         assert infos[0].name == "sum"
         assert infos[0].attr == "STATS_TOTAL"
 
     def test_configure(self):
+        self.o = StatsPluginPart(name="m", mri="BLOCK-STAT")
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
         fileDir = "/tmp"
-        infos = self.o.configure(self.context, fileDir)
+        part_info = {}
+        infos = self.o.configure(self.context, part_info, fileDir)
         assert infos is None
         expected_filename = "/tmp/BLOCK-STAT-attributes.xml"
         assert self.child.handled_requests.mock_calls == [
@@ -44,3 +49,24 @@ class TestStatsPluginPart(ChildTestCase):
             actual_xml = f.read().replace(">", ">\n")
         assert actual_xml.splitlines() == expected_xml.splitlines()
 
+    def test_configure_windows(self):
+        self.o = StatsPluginPart(name="m", mri="BLOCK-STAT", runs_on_windows=True)
+        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.process.start()
+        fileDir = "/tmp"
+        part_info = {"sth": [FilePathTranslatorInfo("X", "/tmp")]}
+        infos = self.o.configure(self.context, part_info, fileDir)
+        assert infos is None
+        expected_filename_unix = "/tmp/BLOCK-STAT-attributes.xml"
+        expected_filename_windows = "X:\\BLOCK-STAT-attributes.xml"
+        assert self.child.handled_requests.mock_calls == [
+            call.put('computeStatistics', True),
+            call.put('enableCallbacks', True),
+            call.put('attributesFile', expected_filename_windows)]
+        expected_xml = """<?xml version="1.0" ?>
+<Attributes>
+<Attribute addr="0" datatype="DOUBLE" description="Sum of the array" name="STATS_TOTAL" source="TOTAL" type="PARAM" />
+</Attributes>"""
+        with open(expected_filename_unix) as f:
+            actual_xml = f.read().replace(">", ">\n")
+        assert actual_xml.splitlines() == expected_xml.splitlines()

--- a/tests/test_modules/test_adUtil/test_reframepluginpart.py
+++ b/tests/test_modules/test_adUtil/test_reframepluginpart.py
@@ -61,5 +61,4 @@ class TestReframePluginPart(ChildTestCase):
             call.put('numImages', 6),
             call.put('postCount', 999),
             call.post('start'),
-            call.when_values_matches('acquiring', True, None, 10.0, None),
-            call.put('attributesFile', '/tmp/mri-attributes.xml')]
+            call.when_values_matches('acquiring', True, None, 10.0, None)]

--- a/tests/test_modules/test_adUtil/test_reframepluginpart.py
+++ b/tests/test_modules/test_adUtil/test_reframepluginpart.py
@@ -25,7 +25,8 @@ class TestReframePluginPart(ChildTestCase):
 
     def test_report(self):
         infos = self.o.report_status()
-        assert infos.rank == 2
+        assert len(infos) == 1
+        assert infos[0].rank == 2
 
     def test_validate(self):
         xs = LineGenerator("x", "mm", 0.0, 0.5, 3, alternate=True)
@@ -52,7 +53,7 @@ class TestReframePluginPart(ChildTestCase):
         # We wait to be armed, so set this here
         self.set_attributes(self.child, acquiring=True)
         self.o.configure(
-            self.context, completed_steps, steps_to_do, {}, generator)
+            self.context, completed_steps, steps_to_do, {}, generator, fileDir="/tmp")
         assert self.child.handled_requests.mock_calls == [
             call.put('arrayCallbacks', True),
             call.put('arrayCounter', 0),
@@ -60,4 +61,5 @@ class TestReframePluginPart(ChildTestCase):
             call.put('numImages', 6),
             call.put('postCount', 999),
             call.post('start'),
-            call.when_values_matches('acquiring', True, None, 10.0, None)]
+            call.when_values_matches('acquiring', True, None, 10.0, None),
+            call.put('attributesFile', '/tmp/mri-attributes.xml')]


### PR DESCRIPTION
Add ability to control which NDAttributes are written to the HDF5 file for an AreaDetector, and additionally allow for extra attributes (either from PVs or asyn params) to be specified to be created & written.