### PR TITLE
Specify additional files in setup.py.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include README.rst
-include CHANGELOG.rst
-include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,9 @@ setup(
         'hdf5': ['h5py', 'vds-gen'],
     },
     include_package_data=True,
+    data_files=[
+        ('', ['README.rst', 'CHANGELOG.rst', 'LICENSE'])
+    ],
     test_suite='nose.collector',
     tests_require=[
  #       'coverage>=3.7.1',


### PR DESCRIPTION
This avoids needing the MANIFEST.in file.

This seems to work for me, but don't assume it's correct. At the moment it doesn't seem like you package `yaml`, `sh`, `svg` files, but presumably either you don't want to or I'm wrong.