### PR TITLE
Gk tidy

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -57,6 +57,130 @@ Docs follow the underlining convention::
     Heading 3
     ~~~~~~~~~
 
+Coding Conventions
+------------------
+
+Any class that takes Annotypes in __init__() will either define those Annotypes
+or import them from its superclass. The Annotypes should all appear in the
+Class namespace so that any further subclasses can in turn import the
+necessary types. To facilitate this and create a tidy namespace, use import
+in __init__.py. To allow 're-import' of the superclass symbols, it is
+necessary to pull them into a variable local to the namespace (in fact this
+is only required for the IDE, but also shows more explicitly what we are doing).
+
+For example, in malcolm.modules.builtin.blockpart create copies of the
+imported Annotypes (The comment is also a convention):
+
+.. code-block:: python
+
+    from ..util import set_tags, AWriteable, AConfig, AGroup, AWidget
+
+    with Anno("Initial value of the created attribute"):
+        AValue = str
+
+    # Pull re-used annotypes into our namespace in case we are subclassed
+    APartName = APartName
+    AMetaDescription = AMetaDescription
+    AWriteable = AWriteable
+    AConfig = AConfig
+    AGroup = AGroup
+    AWidget = AWidget
+
+Next import all the Annotypes from blockpart and its superclasses in
+malcolm.modules.builtin.__init__.py:
+
+.. code-block:: python
+
+    from .blockpart import BlockPart, APartName, AMetaDescription, AWriteable, \
+    AConfig, AGroup, AWidget
+
+When importing from core.modules, import the entire module only. This
+means that all references to the contents of this module will then have an
+explicit module namespace. e.g.:
+
+.. code-block:: python
+
+    from malcolm.modules import builtin, scanning
+
+    def setup(self, registrar):
+        registrar.hook(scanning.hooks.ConfigureHook, self.configure)
+
+Note that this does not apply when importing symbols from other files within
+the same malcolm module. In this case use relative imports (importing a
+parent module is a circular import).
+e.g. in malcolm.modules.demo.filewriterpart.py:
+
+.. code-block:: python
+
+    from ..util import make_gaussian_blob, interesting_pattern
+
+
+When implementing a part do all hook registration using registrar.hook
+in the setup function (not in __init__). e.g.:
+
+.. code-block:: python
+
+    class MotionChildPart(builtin.parts.ChildPart):
+        """Provides control of a `counter_block` within a `RunnableController`"""
+        # Generator instance
+        _generator = None  # type: scanning.hooks.AGenerator
+        # Where to start
+        _completed_steps = None  # type: int
+        # How many steps to do
+        _steps_to_do = None  # type: int
+        # When to blow up
+        _exception_step = None  # type: int
+        # Which axes we should be moving
+        _axes_to_move = None  # type: scanning.hooks.AAxesToMove
+
+        def setup(self, registrar):
+            # type: (PartRegistrar) -> None
+            super(MotionChildPart, self).setup(registrar)
+            # Hooks
+            registrar.hook(scanning.hooks.PreConfigureHook, self.reload)
+            registrar.hook((scanning.hooks.ConfigureHook,
+                            scanning.hooks.PostRunArmedHook,
+                            scanning.hooks.SeekHook), self.configure)
+            registrar.hook((scanning.hooks.RunHook,
+                            scanning.hooks.ResumeHook), self.run)
+            # Tell the controller to expose some extra configure parameters
+            registrar.report(scanning.hooks.ConfigureHook.create_info(
+                self.configure))
+
+Also do not override __init__() just to declare Attributes,
+instead declare them at the class level and initialise to None, then
+create the Attribute model in setup.
+
+TODO: add convenience for supplying private properties as per MotionChildPart
+
+.. code-block:: python
+
+    class CounterPart(Part):
+        """Defines a counter `Attribute` with zero and increment `Method` objects"""
+
+        #: Writeable Attribute holding the current counter value
+        counter = None  # type: AttributeModel
+        #: Writeable Attribute holding the amount to increment() by
+        delta = None  # type: AttributeModel
+
+        def setup(self, registrar):
+            # type: (PartRegistrar) -> None
+            super(CounterPart, self).setup(registrar)
+            # Add some Attribute and Methods to the Block
+            self.counter = NumberMeta(
+                "float64", "The current value of the counter",
+                tags=[config_tag(), Widget.TEXTINPUT.tag()]
+            ).create_attribute_model()
+            registrar.add_attribute_model(
+                "counter", self.counter, self.counter.set_value)
+
+            self.delta = NumberMeta(
+                "float64", "The amount to increment() by",
+                tags=[config_tag(), Widget.TEXTINPUT.tag()]
+            ).create_attribute_model(initial_value=1)
+            registrar.add_attribute_model(
+                "delta", self.delta, self.delta.set_value)
+
 
 Building the docs
 -----------------

--- a/malcolm/core/__init__.py
+++ b/malcolm/core/__init__.py
@@ -7,7 +7,7 @@ from .define import Define
 from .errors import AbortedError, BadValueError, TimeoutError, ResponseError, \
     UnexpectedError, YamlError, FieldError, NotWriteableError
 from .future import Future
-from .hook import Hook, Hookable
+from .hook import Hook, Hookable, AHookable
 from .info import Info
 from .loggable import Loggable
 from .models import BlockModel, AttributeModel, MethodModel, MapMeta, \
@@ -20,8 +20,7 @@ from .moduleutil import submodule_all
 from .notifier import Notifier
 from .part import Part, PartRegistrar, APartName
 from .process import Process, ProcessPublishHook, ProcessStartHook, \
-    ProcessStopHook, APublished, UnpublishedInfo, UUnpublishedInfos, \
-    AHookable
+    ProcessStopHook, APublished, UnpublishedInfo, UUnpublishedInfos
 from .request import Request, PathRequest, Subscribe, Unsubscribe, Get, Put, \
     Post
 from .response import Response, Delta, Update, Return, Error

--- a/malcolm/core/__init__.py
+++ b/malcolm/core/__init__.py
@@ -20,7 +20,8 @@ from .moduleutil import submodule_all
 from .notifier import Notifier
 from .part import Part, PartRegistrar, APartName
 from .process import Process, ProcessPublishHook, ProcessStartHook, \
-    ProcessStopHook, APublished, UnpublishedInfo, UUnpublishedInfos
+    ProcessStopHook, APublished, UnpublishedInfo, UUnpublishedInfos, \
+    AHookable
 from .request import Request, PathRequest, Subscribe, Unsubscribe, Get, Put, \
     Post
 from .response import Response, Delta, Update, Return, Error

--- a/malcolm/core/process.py
+++ b/malcolm/core/process.py
@@ -28,6 +28,9 @@ STOPPING = 3
 with Anno("The list of currently published Controller mris"):
     APublished = Array[str]
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+AHookable = AHookable
+
 
 class UnpublishedInfo(Info):
     def __init__(self, mri):

--- a/malcolm/core/process.py
+++ b/malcolm/core/process.py
@@ -28,9 +28,6 @@ STOPPING = 3
 with Anno("The list of currently published Controller mris"):
     APublished = Array[str]
 
-# Pull re-used annotypes into our namespace in case we are subclassed
-AHookable = AHookable
-
 
 class UnpublishedInfo(Info):
     def __init__(self, mri):

--- a/malcolm/modules/ADAndor/parts/__init__.py
+++ b/malcolm/modules/ADAndor/parts/__init__.py
@@ -1,4 +1,4 @@
-from .andordriverpart import AndorDriverPart
+from .andordriverpart import AndorDriverPart, APartName, AMri
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/ADAndor/parts/andordriverpart.py
+++ b/malcolm/modules/ADAndor/parts/andordriverpart.py
@@ -31,8 +31,8 @@ class AndorDriverPart(ADCore.parts.DetectorDriverPart):
                   steps_to_do,  # type: scanning.hooks.AStepsToDo
                   part_info,  # type: scanning.hooks.APartInfo
                   generator,  # type: scanning.hooks.AGenerator
-                  fileDir,  # type: scanning.util.AFileDir
-                  exposure=0.0,  # type: scanning.util.AExposure
+                  fileDir,  # type: scanning.hooks.AFileDir
+                  exposure=0.0,  # type: scanning.hooks.AExposure
                   **kwargs  # type: **Any
                   ):
         # type: (...) -> None

--- a/malcolm/modules/ADAndor/parts/andordriverpart.py
+++ b/malcolm/modules/ADAndor/parts/andordriverpart.py
@@ -3,10 +3,14 @@ from annotypes import add_call_types, Any
 from malcolm.core import PartRegistrar
 from malcolm.modules import ADCore, scanning, builtin
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = builtin.parts.APartName
+AMri = builtin.parts.AMri
+
 
 class AndorDriverPart(ADCore.parts.DetectorDriverPart):
     def __init__(self, name, mri):
-        # type: (builtin.parts.APartName, builtin.parts.AMri) -> None
+        # type: (APartName, AMri) -> None
         super(AndorDriverPart, self).__init__(name, mri, soft_trigger_modes=[
                 "Internal", "Software"])
         self.exposure = scanning.util.exposure_attribute(min_exposure=0.0)

--- a/malcolm/modules/ADCore/parts/__init__.py
+++ b/malcolm/modules/ADCore/parts/__init__.py
@@ -1,11 +1,12 @@
 from .detectordriverpart import DetectorDriverPart, APartName, AMri, \
-    AMainDatasetUseful, ASoftTriggerModes, USoftTriggerModes
+    AMainDatasetUseful, ASoftTriggerModes, USoftTriggerModes, \
+    AContext, AStepsToDo, ACompletedSteps, APartInfo
 from .exposuredeadtimepart import ExposureDeadtimePart, AInitialAccuracy, \
-    AInitialReadoutTime
-from .hdfwriterpart import HDFWriterPart
-from .positionlabellerpart import PositionLabellerPart
-from .statspluginpart import StatsPluginPart
-from .filepathtranslatorpart import FilepathTranslatorPart
+    AInitialReadoutTime, APartName
+from .hdfwriterpart import HDFWriterPart, APartName, AMri, APartRunsOnWindows
+from .positionlabellerpart import PositionLabellerPart, APartName, AMri
+from .statspluginpart import StatsPluginPart, APartName
+from .filepathtranslatorpart import FilepathTranslatorPart, APartName
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/ADCore/parts/__init__.py
+++ b/malcolm/modules/ADCore/parts/__init__.py
@@ -1,10 +1,9 @@
 from .detectordriverpart import DetectorDriverPart, APartName, AMri, \
-    AMainDatasetUseful, ASoftTriggerModes, USoftTriggerModes, \
-    AContext, AStepsToDo, ACompletedSteps, APartInfo
+    AMainDatasetUseful, ASoftTriggerModes, USoftTriggerModes
 from .exposuredeadtimepart import ExposureDeadtimePart, AInitialAccuracy, \
     AInitialReadoutTime, APartName
 from .hdfwriterpart import HDFWriterPart, APartName, AMri, APartRunsOnWindows
-from .positionlabellerpart import PositionLabellerPart, APartName, AMri
+from .positionlabellerpart import PositionLabellerPart
 from .statspluginpart import StatsPluginPart, APartName
 from .filepathtranslatorpart import FilepathTranslatorPart, APartName
 

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -23,11 +23,6 @@ with Anno("Directory to write data to"):
 # Pull re-used annotypes into our namespace in case we are subclassed
 APartName = APartName
 AMri = builtin.parts.AMri
-AbortHook = scanning.hooks.AbortHook
-AContext = scanning.hooks.AContext
-AStepsToDo = scanning.hooks.AStepsToDo
-ACompletedSteps = scanning.hooks.ACompletedSteps
-APartInfo = scanning.hooks.APartInfo
 
 # We will set these attributes on the child block, so don't save them
 @builtin.util.no_save('arrayCounter', 'imageMode', 'numImages',
@@ -115,7 +110,7 @@ class DetectorDriverPart(builtin.parts.ChildPart):
 
     @add_call_types
     def reset(self, context):
-        # type: (AContext) -> None
+        # type: (scanning.hooks.AContext) -> None
         super(DetectorDriverPart, self).reset(context)
         self.actions.abort_detector(context)
         # Delete the layout XML file
@@ -147,10 +142,10 @@ class DetectorDriverPart(builtin.parts.ChildPart):
     # noinspection PyPep8Naming
     @add_call_types
     def configure(self,
-                  context,  # type: AContext
-                  completed_steps,  # type: ACompletedSteps
-                  steps_to_do,  # type: AStepsToDo
-                  part_info,  # type: APartInfo
+                  context,  # type: scanning.hooks.AContext
+                  completed_steps,  # type: scanning.hooks.ACompletedSteps
+                  steps_to_do,  # type: scanning.hooks.AStepsToDo
+                  part_info,  # type: scanning.hooks.APartInfo
                   generator,  # type: scanning.util.AGenerator
                   fileDir,  # type: AFileDir
                   **kwargs  # type: **Any
@@ -200,7 +195,7 @@ class DetectorDriverPart(builtin.parts.ChildPart):
 
     @add_call_types
     def run(self, context):
-        # type: (AContext) -> None
+        # type: (scanning.hooks.AContext) -> None
         if not self.is_hardware_triggered:
             # Start now if we are software triggered
             self.actions.arm_detector(context)
@@ -208,5 +203,5 @@ class DetectorDriverPart(builtin.parts.ChildPart):
 
     @add_call_types
     def abort(self, context):
-        # type: (AContext) -> None
+        # type: (scanning.hooks.AContext) -> None
         self.actions.abort_detector(context)

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -17,8 +17,6 @@ with Anno("Is main detector dataset useful to publish in DatasetTable?"):
 with Anno("List of trigger modes that do not use hardware triggers"):
     ASoftTriggerModes = Array[str]
 USoftTriggerModes = Union[ASoftTriggerModes, Sequence[str]]
-with Anno("Directory to write data to"):
-    AFileDir = str
 
 # Pull re-used annotypes into our namespace in case we are subclassed
 APartName = APartName
@@ -146,8 +144,8 @@ class DetectorDriverPart(builtin.parts.ChildPart):
                   completed_steps,  # type: scanning.hooks.ACompletedSteps
                   steps_to_do,  # type: scanning.hooks.AStepsToDo
                   part_info,  # type: scanning.hooks.APartInfo
-                  generator,  # type: scanning.util.AGenerator
-                  fileDir,  # type: AFileDir
+                  generator,  # type: scanning.hooks.AGenerator
+                  fileDir,  # type: scanning.hooks.AFileDir
                   **kwargs  # type: **Any
                   ):
         # type: (...) -> None

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -56,17 +56,6 @@ class DetectorDriverPart(builtin.parts.ChildPart):
             extra_tags=[config_tag()]
         ).create_attribute_model()
         self.runs_on_windows = runs_on_windows
-        # Hooks
-        self.register_hooked(
-            scanning.hooks.ReportStatusHook, self.report_status)
-        self.register_hooked((scanning.hooks.ConfigureHook,
-                              scanning.hooks.PostRunArmedHook,
-                              scanning.hooks.SeekHook),
-                             self.configure, self.configure_args_with_exposure)
-        self.register_hooked(
-            (scanning.hooks.RunHook, scanning.hooks.ResumeHook), self.run)
-        self.register_hooked(
-            (scanning.hooks.PauseHook, scanning.hooks.AbortHook), self.abort)
 
     def build_attribute_xml(self):
         root_el = ET.Element("Attributes")
@@ -109,6 +98,17 @@ class DetectorDriverPart(builtin.parts.ChildPart):
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         super(DetectorDriverPart, self).setup(registrar)
+        # Hooks
+        registrar.hook(scanning.hooks.ReportStatusHook, self.report_status)
+        registrar.hook((scanning.hooks.ConfigureHook,
+                        scanning.hooks.PostRunArmedHook,
+                        scanning.hooks.SeekHook),
+                       self.configure, self.configure_args_with_exposure)
+        registrar.hook(
+            (scanning.hooks.RunHook, scanning.hooks.ResumeHook), self.run)
+        registrar.hook(
+            (scanning.hooks.PauseHook, scanning.hooks.AbortHook), self.abort)
+        # Attributes
         registrar.add_attribute_model("attributesToCapture",
                                       self.extra_attributes,
                                       self.set_extra_attributes)

--- a/malcolm/modules/ADCore/parts/exposuredeadtimepart.py
+++ b/malcolm/modules/ADCore/parts/exposuredeadtimepart.py
@@ -64,7 +64,7 @@ class ExposureDeadtimePart(Part):
 
     @add_call_types
     def validate(self, generator, exposure=0.0):
-        # type: (scanning.hooks.AGenerator, scanning.util.AExposure) -> None
+        # type: (scanning.hooks.AGenerator, scanning.hooks.AExposure) -> None
         info = self.report_status()
         info.calculate_exposure(generator.duration, exposure)
 
@@ -81,7 +81,7 @@ class ExposureDeadtimePart(Part):
     # noinspection PyPep8Naming
     @add_call_types
     def configure(self, generator, exposure=0.0):
-        # type: (scanning.hooks.AGenerator, scanning.util.AExposure) -> None
+        # type: (scanning.hooks.AGenerator, scanning.hooks.AExposure) -> None
         info = self.report_status()
         self.exposure.set_value(
             info.calculate_exposure(generator.duration, exposure))

--- a/malcolm/modules/ADCore/parts/exposuredeadtimepart.py
+++ b/malcolm/modules/ADCore/parts/exposuredeadtimepart.py
@@ -43,17 +43,14 @@ class ExposureDeadtimePart(Part):
         ).create_attribute_model(initial_frequency_accuracy)
         self.min_exposure = min_exposure
         self.exposure = scanning.util.exposure_attribute(min_exposure)
-        # Hooks
-        self.register_hooked(
-            scanning.hooks.ReportStatusHook, self.report_status)
-        self.register_hooked(
-            scanning.hooks.ValidateHook, self.validate)
-        self.register_hooked(
-            scanning.hooks.ConfigureHook, self.configure)
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         super(ExposureDeadtimePart, self).setup(registrar)
+        # Hooks
+        registrar.hook(scanning.hooks.ReportStatusHook, self.report_status)
+        registrar.hook(scanning.hooks.ValidateHook, self.validate)
+        registrar.hook(scanning.hooks.ConfigureHook, self.configure)
         # Attributes
         registrar.add_attribute_model(
             "readoutTime", self.readout_time, self.readout_time.set_value)

--- a/malcolm/modules/ADCore/parts/exposuredeadtimepart.py
+++ b/malcolm/modules/ADCore/parts/exposuredeadtimepart.py
@@ -18,6 +18,9 @@ with Anno(frequency_accuracy_desc):
 with Anno("The minimum exposure time this detector will accept"):
     AMinExposure = float
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+
 
 class ExposureDeadtimePart(Part):
     def __init__(self,

--- a/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
+++ b/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
@@ -36,13 +36,12 @@ class FilepathTranslatorPart(Part):
             path_prefix_desc,
             tags=[Widget.TEXTINPUT.tag(), config_tag()],
         ).create_attribute_model(initial_path_prefix)
-        # Hooks
-        self.register_hooked(
-            scanning.hooks.ReportStatusHook, self.report_status)
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         super(FilepathTranslatorPart, self).setup(registrar)
+        # Hooks
+        registrar.hook(scanning.hooks.ReportStatusHook, self.report_status)
         # Attributes
         registrar.add_attribute_model(
             "windowsDriveLetter", self.windows_drive_letter,

--- a/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
+++ b/malcolm/modules/ADCore/parts/filepathtranslatorpart.py
@@ -16,6 +16,9 @@ path_prefix_desc = \
 with Anno(path_prefix_desc):
     APathPrefix = str
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+
 
 class FilepathTranslatorPart(Part):
     def __init__(self,

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -315,9 +315,9 @@ class HDFWriterPart(builtin.parts.ChildPart):
                   steps_to_do,  # type: scanning.hooks.AStepsToDo
                   part_info,  # type: scanning.hooks.APartInfo
                   generator,  # type: scanning.hooks.AGenerator
-                  fileDir,  # type: scanning.util.AFileDir
-                  formatName="det",  # type: scanning.util.AFormatName
-                  fileTemplate="%s.h5",  # type: scanning.util.AFileTemplate
+                  fileDir,  # type: scanning.hooks.AFileDir
+                  formatName="det",  # type: scanning.hooks.AFormatName
+                  fileTemplate="%s.h5",  # type: scanning.hooks.AFileTemplate
                   ):
         # type: (...) -> scanning.hooks.UInfos
         # On initial configure, expect to get the demanded number of frames

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -265,21 +265,12 @@ class HDFWriterPart(builtin.parts.ChildPart):
         self.runs_on_windows = runs_on_windows
         # How long to wait between frame updates before error
         self.frame_timeout = 0.0
-        # Hooks
         self.write_all_nd_attributes = BooleanMeta(
             "Toggles whether all NDAttributes are written to "
             "file, or only those specified in the dataset",
             writeable=True,
             tags=[Widget.CHECKBOX.tag(), config_tag()]).create_attribute_model(
             write_all_nd_attributes)
-        self.register_hooked(scanning.hooks.ConfigureHook, self.configure)
-        self.register_hooked((scanning.hooks.PostRunArmedHook,
-                              scanning.hooks.SeekHook), self.seek)
-        self.register_hooked((scanning.hooks.RunHook,
-                              scanning.hooks.ResumeHook), self.run)
-        self.register_hooked(scanning.hooks.PostRunReadyHook,
-                             self.post_run_ready)
-        self.register_hooked(scanning.hooks.AbortHook, self.abort)
 
     @add_call_types
     def reset(self, context):
@@ -299,6 +290,15 @@ class HDFWriterPart(builtin.parts.ChildPart):
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         super(HDFWriterPart, self).setup(registrar)
+        # Hooks
+        registrar.hook(scanning.hooks.ConfigureHook, self.configure)
+        registrar.hook((scanning.hooks.PostRunArmedHook,
+                        scanning.hooks.SeekHook), self.seek)
+        registrar.hook((scanning.hooks.RunHook,
+                        scanning.hooks.ResumeHook), self.run)
+        registrar.hook(scanning.hooks.PostRunReadyHook, self.post_run_ready)
+        registrar.hook(scanning.hooks.AbortHook, self.abort)
+        # Attributes
         registrar.add_attribute_model("writeAllNdAttributes",
                                       self.write_all_nd_attributes,
                                       self.write_all_nd_attributes.set_value)

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -1,5 +1,4 @@
 import os
-import math
 import time
 from xml.etree import cElementTree as ET
 
@@ -13,8 +12,6 @@ from malcolm.modules import builtin, scanning
 from ..infos import CalculatedNDAttributeDatasetInfo, NDArrayDatasetInfo, \
     NDAttributeDatasetInfo, \
     AttributeDatasetType, FilePathTranslatorInfo
-from malcolm.modules.scanning.infos import DatasetProducedInfo
-from malcolm.modules.scanning.util import DatasetType
 from ..util import APartRunsOnWindows
 
 if TYPE_CHECKING:
@@ -30,6 +27,11 @@ FRAME_TIMEOUT = 60
 
 with Anno("Toggle writing of all ND attributes to HDF file"):
     AWriteAllNDAttributes = bool
+
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMri = builtin.parts.AMri
+APartRunsOnWindows = APartRunsOnWindows
 
 
 def greater_than_zero(v):
@@ -51,10 +53,10 @@ def create_dataset_infos(name, part_info, generator, filename):
     # Add the primary datasource
     if ndarray_infos:
         ndarray_info = ndarray_infos[0]
-        yield DatasetProducedInfo(
+        yield scanning.infos.DatasetProducedInfo(
             name="%s.data" % name,
             filename=filename,
-            type=DatasetType.PRIMARY,
+            type=scanning.util.DatasetType.PRIMARY,
             rank=ndarray_info.rank + generator_rank,
             path="/entry/detector/detector",
             uniqueid=uniqueid)
@@ -62,10 +64,10 @@ def create_dataset_infos(name, part_info, generator, filename):
         # Add any secondary datasources
         for calculated_info in \
                 CalculatedNDAttributeDatasetInfo.filter_values(part_info):
-            yield DatasetProducedInfo(
+            yield scanning.infos.DatasetProducedInfo(
                 name="%s.%s" % (name, calculated_info.name),
                 filename=filename,
-                type=DatasetType.SECONDARY,
+                type=scanning.util.DatasetType.SECONDARY,
                 rank=ndarray_info.rank + generator_rank,
                 path="/entry/%s/%s" % (
                     calculated_info.name, calculated_info.name),
@@ -76,32 +78,32 @@ def create_dataset_infos(name, part_info, generator, filename):
         if dataset_info.type is AttributeDatasetType.DETECTOR:
             # Something like I0
             name = "%s.data" % dataset_info.name
-            type = DatasetType.PRIMARY
+            dtype = scanning.util.DatasetType.PRIMARY
         elif dataset_info.type is AttributeDatasetType.MONITOR:
             # Something like Iref
             name = "%s.data" % dataset_info.name
-            type = DatasetType.MONITOR
+            dtype = scanning.util.DatasetType.MONITOR
         elif dataset_info.type is AttributeDatasetType.POSITION:
             # Something like x
             name = "%s.value" % dataset_info.name
-            type = DatasetType.POSITION_VALUE
+            dtype = scanning.util.DatasetType.POSITION_VALUE
         else:
             raise AttributeError("Bad dataset type %r, should be a %s" % (
                 dataset_info.type, AttributeDatasetType))
-        yield DatasetProducedInfo(
+        yield scanning.infos.DatasetProducedInfo(
             name=name,
             filename=filename,
-            type=type,
+            type=dtype,
             rank=dataset_info.rank + generator_rank,
             path="/entry/%s/%s" % (dataset_info.name, dataset_info.name),
             uniqueid=uniqueid)
 
     # Add any setpoint dimensions
     for dim in generator.axes:
-        yield DatasetProducedInfo(
+        yield scanning.infos.DatasetProducedInfo(
             name="%s.value_set" % dim,
             filename=filename,
-            type=DatasetType.POSITION_SET,
+            type=scanning.util.DatasetType.POSITION_SET,
             rank=1,
             path="/entry/detector/%s_set" % dim, uniqueid="")
 
@@ -175,7 +177,7 @@ def make_nxdata(name, rank, entry_el, generator, link=False):
 
 
 def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
-    # type: (CompoundGenerator, PartInfo) -> str
+    # type: (CompoundGenerator, PartInfo, bool) -> str
     # Make a root element with an NXEntry
     root_el = ET.Element("hdf5_layout", auto_ndattr_default="false")
     entry_el = ET.SubElement(root_el, "group", name="entry")
@@ -218,13 +220,13 @@ def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
 
     # Add a group for attributes
     ndattr_default = "true" if write_all_nd_attributes else "false"
-    NDAttributes_el = ET.SubElement(entry_el, "group", name="NDAttributes",
-                                    ndattr_default=ndattr_default)
-    ET.SubElement(NDAttributes_el, "attribute", name="NX_class",
+    nd_attributes_el = ET.SubElement(entry_el, "group", name="NDAttributes",
+                                     ndattr_default=ndattr_default)
+    ET.SubElement(nd_attributes_el, "attribute", name="NX_class",
                   source="constant", value="NXcollection", type="string")
-    ET.SubElement(NDAttributes_el, "dataset", name="NDArrayUniqueId",
+    ET.SubElement(nd_attributes_el, "dataset", name="NDArrayUniqueId",
                   source="ndattribute", ndattribute="NDArrayUniqueId")
-    ET.SubElement(NDAttributes_el, "dataset", name="NDArrayTimeStamp",
+    ET.SubElement(nd_attributes_el, "dataset", name="NDArrayTimeStamp",
                   source="ndattribute", ndattribute="NDArrayTimeStamp")
 
     xml = et_to_string(root_el)
@@ -241,10 +243,11 @@ def make_layout_xml(generator, part_info, write_all_nd_attributes=False):
 @builtin.util.no_save("extraDimSize%s" % SUFFIXES[i] for i in range(10))
 class HDFWriterPart(builtin.parts.ChildPart):
     """Part for controlling an `hdf_writer_block` in a Device"""
+
     def __init__(self,
-                 name,                          # type: APartName
-                 mri,                           # type: builtin.parts.AMri
-                 runs_on_windows=False,         # type: APartRunsOnWindows
+                 name,  # type: APartName
+                 mri,  # type: AMri
+                 runs_on_windows=False,  # type: APartRunsOnWindows
                  write_all_nd_attributes=True,  # type: AWriteAllNDAttributes
                  ):
         # type: (...) -> None

--- a/malcolm/modules/ADCore/parts/positionlabellerpart.py
+++ b/malcolm/modules/ADCore/parts/positionlabellerpart.py
@@ -29,21 +29,18 @@ AMri = builtin.parts.AMri
 class PositionLabellerPart(builtin.parts.ChildPart):
     """Part for controlling a `position_labeller_block` in a scan"""
 
-    def __init__(self, name, mri):
-        # type: (APartName, AMri) -> None
-        super(PositionLabellerPart, self).__init__(name, mri)
-        # Stored generator for positions
-        self.generator = None
-        # The last index we have loaded
-        self.end_index = 0
-        # Where we should stop loading points
-        self.steps_up_to = 0
-        # Future for plugin run
-        self.start_future = None
-        # If we are currently loading then block loading more points
-        self.loading = False
-        # When arrayCounter gets to here we are done
-        self.done_when_reaches = 0
+    # Stored generator for positions
+    generator = None
+    # The last index we have loaded
+    end_index = None
+    # Where we should stop loading points
+    steps_up_to = None
+    # Future for plugin run
+    start_future = None
+    # If we are currently loading then block loading more points
+    loading = None
+    # When arrayCounter gets to here we are done
+    done_when_reaches = None
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None

--- a/malcolm/modules/ADCore/parts/positionlabellerpart.py
+++ b/malcolm/modules/ADCore/parts/positionlabellerpart.py
@@ -18,6 +18,10 @@ N_LOAD_AHEAD = 4
 if TYPE_CHECKING:
     from typing import Tuple
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMri = builtin.parts.AMri
+
 
 # We will set these attributes on the child block, so don't save them
 @builtin.util.no_save(
@@ -26,7 +30,7 @@ class PositionLabellerPart(builtin.parts.ChildPart):
     """Part for controlling a `position_labeller_block` in a scan"""
 
     def __init__(self, name, mri):
-        # type: (APartName, builtin.parts.AMri) -> None
+        # type: (APartName, AMri) -> None
         super(PositionLabellerPart, self).__init__(name, mri)
         # Stored generator for positions
         self.generator = None

--- a/malcolm/modules/ADCore/parts/positionlabellerpart.py
+++ b/malcolm/modules/ADCore/parts/positionlabellerpart.py
@@ -18,10 +18,6 @@ N_LOAD_AHEAD = 4
 if TYPE_CHECKING:
     from typing import Tuple
 
-# Pull re-used annotypes into our namespace in case we are subclassed
-APartName = APartName
-AMri = builtin.parts.AMri
-
 
 # We will set these attributes on the child block, so don't save them
 @builtin.util.no_save(

--- a/malcolm/modules/ADCore/parts/positionlabellerpart.py
+++ b/malcolm/modules/ADCore/parts/positionlabellerpart.py
@@ -3,7 +3,7 @@ from xml.etree import cElementTree as ET
 from annotypes import TYPE_CHECKING, add_call_types, Any
 
 from malcolm.compat import et_to_string
-from malcolm.core import APartName, Hook
+from malcolm.core import APartName, PartRegistrar
 from malcolm.modules import builtin, scanning
 
 # How big an XML file can the EPICS waveform receive?
@@ -44,15 +44,19 @@ class PositionLabellerPart(builtin.parts.ChildPart):
         self.loading = False
         # When arrayCounter gets to here we are done
         self.done_when_reaches = 0
-        # Hooks
-        self.register_hooked((scanning.hooks.ConfigureHook,
-                              scanning.hooks.PostRunArmedHook,
-                              scanning.hooks.SeekHook), self.configure)
-        self.register_hooked((scanning.hooks.RunHook,
-                              scanning.hooks.ResumeHook), self.run)
-        self.register_hooked((scanning.hooks.AbortHook,
-                              scanning.hooks.PauseHook), self.abort)
 
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(PositionLabellerPart, self).setup(registrar)
+        # Hooks
+        registrar.hook((scanning.hooks.ConfigureHook,
+                        scanning.hooks.PostRunArmedHook,
+                        scanning.hooks.SeekHook), self.configure)
+        registrar.hook((scanning.hooks.RunHook,
+                        scanning.hooks.ResumeHook), self.run)
+        registrar.hook((scanning.hooks.AbortHook,
+                        scanning.hooks.PauseHook), self.abort)
+        
     @add_call_types
     def reset(self, context):
         # type: (scanning.hooks.AContext) -> None

--- a/malcolm/modules/ADCore/parts/positionlabellerpart.py
+++ b/malcolm/modules/ADCore/parts/positionlabellerpart.py
@@ -49,7 +49,7 @@ class PositionLabellerPart(builtin.parts.ChildPart):
                         scanning.hooks.ResumeHook), self.run)
         registrar.hook((scanning.hooks.AbortHook,
                         scanning.hooks.PauseHook), self.abort)
-        
+
     @add_call_types
     def reset(self, context):
         # type: (scanning.hooks.AContext) -> None

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -70,7 +70,7 @@ class StatsPluginPart(builtin.parts.ChildPart):
     def configure(self,
                   context,  # type: scanning.hooks.AContext
                   part_info,  # type: scanning.hooks.APartInfo
-                  fileDir  # type: scanning.util.AFileDir
+                  fileDir  # type: scanning.hooks.AFileDir
                   ):
         # type: (...) -> None
         child = context.block_view(self.mri)

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -4,7 +4,7 @@ from xml.etree import cElementTree as ET
 from annotypes import Anno, add_call_types
 
 from malcolm.compat import et_to_string
-from malcolm.core import APartName
+from malcolm.core import APartName, PartRegistrar
 from malcolm.modules import builtin, scanning
 from ..infos import CalculatedNDAttributeDatasetInfo, FilePathTranslatorInfo
 from ..util import StatisticsName, APartRunsOnWindows
@@ -36,10 +36,13 @@ class StatsPluginPart(builtin.parts.ChildPart):
         # The NDAttributes file we write to say what to capture
         self.attributes_filename = None  # type: str
         self.runs_on_windows = runs_on_windows
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(StatsPluginPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(scanning.hooks.ReportStatusHook,
-                             self.report_status)
-        self.register_hooked(scanning.hooks.ConfigureHook, self.configure)
+        registrar.hook(scanning.hooks.ReportStatusHook, self.report_status)
+        registrar.hook(scanning.hooks.ConfigureHook, self.configure)
 
     @add_call_types
     def report_status(self):

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -14,6 +14,9 @@ with Anno("Which statistic to capture"):
 with Anno("Directory to write data to"):
     AFileDir = str
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+
 
 # We will set these attributes on the child block, so don't save them
 @builtin.util.no_save(

--- a/malcolm/modules/ADOdin/parts/__init__.py
+++ b/malcolm/modules/ADOdin/parts/__init__.py
@@ -1,4 +1,4 @@
-from .odinwriterpart import OdinWriterPart
+from .odinwriterpart import OdinWriterPart, AMri, APartName
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/ADOdin/parts/odinwriterpart.py
+++ b/malcolm/modules/ADOdin/parts/odinwriterpart.py
@@ -187,28 +187,14 @@ def add_nexus_nodes(generator, vds_file_path):
 class OdinWriterPart(builtin.parts.ChildPart):
     """Part for controlling an `hdf_writer_block` in a Device"""
 
-    def __init__(self, name, mri):
-        # type: (APartName, AMri) -> None
-        super(OdinWriterPart, self).__init__(name, mri)
-        # Future for the start action
-        self.start_future = None  # type: Future
-        self.array_future = None  # type: Future
-        self.done_when_reaches = 0
-        # CompletedSteps = arrayCounter + self.uniqueid_offset
-        self.unique_id_offset = 0
-        # The HDF5 layout file we write to say where the datasets go
-        self.layout_filename = None  # type: str
-        # Hooks
-        self.register_hooked(scanning.hooks.ConfigureHook, self.configure)
-        self.register_hooked((scanning.hooks.PostRunArmedHook,
-                              scanning.hooks.SeekHook), self.seek)
-        self.register_hooked((scanning.hooks.RunHook,
-                              scanning.hooks.ResumeHook), self.run)
-        self.register_hooked(scanning.hooks.PostRunReadyHook,
-                             self.post_run_ready)
-        self.register_hooked(scanning.hooks.AbortHook, self.abort)
-        self.register_hooked(scanning.hooks.PauseHook, self.pause)
-        self.exposure_time = 0
+    # Future for the start action
+    start_future = None  # type: Future
+    array_future = None  # type: Future
+    done_when_reaches = None  # type: int
+    unique_id_offset = None  # type: int
+    # The HDF5 layout file we write to say where the datasets go
+    layout_filename = None  # type: str
+    exposure_time = None  # type: float
 
     @add_call_types
     def reset(self, context):
@@ -222,6 +208,15 @@ class OdinWriterPart(builtin.parts.ChildPart):
         # Tell the controller to expose some extra configure parameters
         registrar.report(scanning.hooks.ConfigureHook.create_info(
             self.configure))
+        # Hooks
+        registrar.hook(scanning.hooks.ConfigureHook, self.configure)
+        registrar.hook((scanning.hooks.PostRunArmedHook,
+                        scanning.hooks.SeekHook), self.seek)
+        registrar.hook((scanning.hooks.RunHook,
+                        scanning.hooks.ResumeHook), self.run)
+        registrar.hook(scanning.hooks.PostRunReadyHook, self.post_run_ready)
+        registrar.hook(scanning.hooks.AbortHook, self.abort)
+        registrar.hook(scanning.hooks.PauseHook, self.pause)
 
     @add_call_types
     def pause(self, context):

--- a/malcolm/modules/ADOdin/parts/odinwriterpart.py
+++ b/malcolm/modules/ADOdin/parts/odinwriterpart.py
@@ -231,9 +231,9 @@ class OdinWriterPart(builtin.parts.ChildPart):
                   completed_steps,  # type: scanning.hooks.ACompletedSteps
                   steps_to_do,  # type: scanning.hooks.AStepsToDo
                   generator,  # type: scanning.hooks.AGenerator
-                  fileDir,  # type: scanning.util.AFileDir
-                  formatName="odin",  # type: scanning.util.AFormatName
-                  fileTemplate="%s.h5",  # type: scanning.util.AFileTemplate
+                  fileDir,  # type: scanning.hooks.AFileDir
+                  formatName="odin",  # type: scanning.hooks.AFormatName
+                  fileTemplate="%s.h5",  # type: scanning.hooks.AFileTemplate
                   ):
         # type: (...) -> scanning.hooks.UInfos
 

--- a/malcolm/modules/ADOdin/parts/odinwriterpart.py
+++ b/malcolm/modules/ADOdin/parts/odinwriterpart.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 # stalled and raise
 FRAME_TIMEOUT = 60
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMri = builtin.parts.AMri
+
 
 def greater_than_zero(v):
     # type: (int) -> bool
@@ -184,7 +188,7 @@ class OdinWriterPart(builtin.parts.ChildPart):
     """Part for controlling an `hdf_writer_block` in a Device"""
 
     def __init__(self, name, mri):
-        # type: (APartName, builtin.parts.AMri) -> None
+        # type: (APartName, AMri) -> None
         super(OdinWriterPart, self).__init__(name, mri)
         # Future for the start action
         self.start_future = None  # type: Future

--- a/malcolm/modules/ADPandABlocks/controllers/__init__.py
+++ b/malcolm/modules/ADPandABlocks/controllers/__init__.py
@@ -1,4 +1,6 @@
-from .pandarunnablecontroller import PandARunnableController
+from .pandarunnablecontroller import PandARunnableController, \
+    AMri, AConfigDir, AHostname, APort, APollPeriod, ATemplateDesigns, \
+    AInitialDesign, AUseGit, ADescription
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/ADPandABlocks/controllers/pandarunnablecontroller.py
+++ b/malcolm/modules/ADPandABlocks/controllers/pandarunnablecontroller.py
@@ -1,10 +1,7 @@
 from annotypes import Anno
 
-from malcolm.modules.pandablocks.controllers.pandablockcontroller import \
-    PandABlockController
 from malcolm.modules import ADCore, scanning, pandablocks, builtin
 from ..parts.pandadatasetbussespart import PandADatasetBussesPart
-
 
 with Anno("Prefix for areaDetector records"):
     APrefix = str
@@ -20,8 +17,9 @@ AUseGit = pandablocks.controllers.AUseGit
 ADescription = pandablocks.controllers.ADescription
 
 
-class PandAStatefulBlockController(PandABlockController,
-                                   builtin.controllers.StatefulController):
+class PandAStatefulBlockController(
+    pandablocks.controllers.pandablockcontroller.PandABlockController,
+        builtin.controllers.StatefulController):
     pass
 
 
@@ -70,5 +68,5 @@ class PandARunnableController(pandablocks.controllers.PandAManagerController,
                 name=block_name, mri=controller.mri, main_dataset_useful=False)
             return controller, child_part
         else:
-            return super(PandARunnableController, self).\
+            return super(PandARunnableController, self). \
                 _make_child_block(block_name, block_data)

--- a/malcolm/modules/ADPandABlocks/parts/__init__.py
+++ b/malcolm/modules/ADPandABlocks/parts/__init__.py
@@ -1,4 +1,4 @@
-from .pandablockspcomppart import PandABlocksPcompPart
+from .pandablockspcomppart import PandABlocksPcompPart, APartName, AMri
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/ADPandABlocks/parts/pandablockspcomppart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandablockspcomppart.py
@@ -4,7 +4,7 @@ from __future__ import division
 from annotypes import add_call_types, Anno, TYPE_CHECKING
 from scanpointgenerator import Point
 
-from malcolm.core import APartName, Block, Attribute, Context
+from malcolm.core import APartName, Block, Attribute, Context, PartRegistrar
 from malcolm.modules import builtin, scanning, pmac
 
 from ..util import SequencerTable, Trigger
@@ -141,11 +141,13 @@ class PandABlocksPcompPart(builtin.parts.ChildPart):
         self.min_turnaround = 0
         # The sequencer tables
         self.seq_tables = []
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(PandABlocksPcompPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(scanning.hooks.ConfigureHook,
-                             self.configure)
-        self.register_hooked(scanning.hooks.RunHook,
-                             self.run)
+        registrar.hook(scanning.hooks.ConfigureHook, self.configure)
+        registrar.hook(scanning.hooks.RunHook, self.run)
 
     # Allow CamelCase as these parameters will be serialized
     # noinspection PyPep8Naming

--- a/malcolm/modules/ADPandABlocks/parts/pandablockspcomppart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandablockspcomppart.py
@@ -6,7 +6,6 @@ from scanpointgenerator import Point
 
 from malcolm.core import APartName, Block, Attribute, Context
 from malcolm.modules import builtin, scanning, pmac
-from malcolm.modules.scanning.infos import MinTurnaroundInfo
 
 from ..util import SequencerTable, Trigger
 
@@ -21,6 +20,10 @@ SEQ_TABLE_ROWS = 4096
 
 with Anno("Scannable name for sequencer input"):
     APos = str
+
+# Pull re-used annotypes into our namespace in case we are subclassed
+AMri = builtin.parts.AMri
+APartName = APartName
 
 # How long is a single tick if prescaler is 0
 TICK = 8e-9
@@ -85,7 +88,7 @@ def _get_blocks(context, panda_mri):
     for source, export in panda.exports.value.rows():
         if export in SEQ_TABLES:
             assert source.endswith(".table"), \
-                "Expected export %s to come from SEQx.table, got %s" %(
+                "Expected export %s to come from SEQx.table, got %s" % (
                     export, source)
             seq_part_names[source[:-len(".table")]] = export
     assert tuple(sorted(seq_part_names.values())) == SEQ_TABLES, \
@@ -110,7 +113,7 @@ class PandABlocksPcompPart(builtin.parts.ChildPart):
     compare"""
 
     def __init__(self, name, mri, posa, posb="", posc=""):
-        # type: (APartName, builtin.parts.AMri, APos, APos, APos) -> None
+        # type: (APartName, AMri, APos, APos, APos) -> None
         super(PandABlocksPcompPart, self).__init__(name, mri, stateful=False)
         # Store scannable names
         self.scannables = (posa, posb, posc)
@@ -165,7 +168,7 @@ class PandABlocksPcompPart(builtin.parts.ChildPart):
         panda_mri = context.block_view(self.mri).panda.value
         pmac_mri = context.block_view(self.mri).pmac.value
         # See if there is a minimum turnaround
-        infos = MinTurnaroundInfo.filter_values(part_info)
+        infos = scanning.infos.MinTurnaroundInfo.filter_values(part_info)
         if infos:
             assert len(infos) == 1, \
                 "Expected 0 or 1 MinTurnaroundInfos, got %d" % len(infos)
@@ -282,5 +285,3 @@ class PandABlocksPcompPart(builtin.parts.ChildPart):
     def run(self, context):
         # type: (scanning.hooks.AContext) -> None
         pass
-
-

--- a/malcolm/modules/ADPandABlocks/parts/pandadatasetbussespart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandadatasetbussespart.py
@@ -17,8 +17,8 @@ class PandADatasetBussesPart(pandablocks.parts.pandabussespart.PandABussesPart):
         # type: (PartRegistrar) -> None
         super(PandADatasetBussesPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(scanning.hooks.ReportStatusHook,
-                             self.report_status)
+        registrar.hook(scanning.hooks.ReportStatusHook,
+                       self.report_status)
 
     @staticmethod
     def _make_initial_bits_table(bit_names):

--- a/malcolm/modules/ADPandABlocks/parts/pandadatasetbussespart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandadatasetbussespart.py
@@ -1,15 +1,14 @@
 from annotypes import TYPE_CHECKING
 
 from malcolm.core import PartRegistrar
-from malcolm.modules import pandablocks
-from malcolm.modules import scanning, ADCore
+from malcolm.modules import scanning, ADCore, pandablocks
 from ..util import DatasetBitsTable, DatasetPositionsTable
 
 if TYPE_CHECKING:
     from typing import List
 
 
-class PandADatasetBussesPart(pandablocks.parts.pandabussespart.PandABussesPart):
+class PandADatasetBussesPart(pandablocks.parts.PandABussesPart):
     bits_table_cls = DatasetBitsTable
     positions_table_cls = DatasetPositionsTable
 

--- a/malcolm/modules/ADPandABlocks/parts/pandadatasetbussespart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandadatasetbussespart.py
@@ -1,8 +1,7 @@
 from annotypes import TYPE_CHECKING
 
 from malcolm.core import PartRegistrar
-from malcolm.modules.pandablocks.parts.pandabussespart import PandABussesPart
-from malcolm.modules.pandablocks.util import PositionCapture
+from malcolm.modules import pandablocks
 from malcolm.modules import scanning, ADCore
 from ..util import DatasetBitsTable, DatasetPositionsTable
 
@@ -10,7 +9,7 @@ if TYPE_CHECKING:
     from typing import List
 
 
-class PandADatasetBussesPart(PandABussesPart):
+class PandADatasetBussesPart(pandablocks.parts.pandabussespart.PandABussesPart):
     bits_table_cls = DatasetBitsTable
     positions_table_cls = DatasetPositionsTable
 
@@ -49,7 +48,7 @@ class PandADatasetBussesPart(PandABussesPart):
             units=[""] * len(pos_names),
             scale=[1.0] * len(pos_names),
             offset=[0.0] * len(pos_names),
-            capture=[PositionCapture.NO] * len(pos_names),
+            capture=[pandablocks.util.PositionCapture.NO] * len(pos_names),
             datasetName=[""] * len(pos_names),
             datasetType=ds_types
         )
@@ -69,7 +68,7 @@ class PandADatasetBussesPart(PandABussesPart):
         pos_table = self.positions.value  # type: DatasetPositionsTable
         for i, capture in enumerate(pos_table.capture):
             ds_name = pos_table.datasetName[i]
-            if ds_name and capture != PositionCapture.NO:
+            if ds_name and capture != pandablocks.util.PositionCapture.NO:
                 # If we have Min Max Mean, just take Mean
                 capture_suffix = capture.value.split(" ")[-1]
                 ret.append(ADCore.infos.NDAttributeDatasetInfo(

--- a/malcolm/modules/ADPandABlocks/util.py
+++ b/malcolm/modules/ADPandABlocks/util.py
@@ -2,11 +2,8 @@ from annotypes import Anno, Array
 import numpy as np
 
 from malcolm.core import Table
-from malcolm.modules.ADCore.util import UAttributeNames, AAttributeNames, \
-    UAttributeTypes, AAttributeTypes
-from malcolm.modules.pandablocks.util import BitsTable, UBitNames, UBitValues, \
-    UBitCaptures, PositionsTable, UPositionNames, UPositionValues, \
-    UPositionUnits, UPositionScales, UPositionOffsets, UPositionCaptures
+from malcolm.modules import ADCore
+from malcolm.modules import pandablocks
 
 
 class Trigger(object):
@@ -38,6 +35,24 @@ with Anno("The time that the phase should take"):
     ATimeArray = Array[np.uint32]
 with Anno("Output value during the phase"):
     AOutArray = Array[bool]
+
+# TODO - WHAT GIVES HERE ?? -
+#  AAttributeNames and AAttributeNames causes an IDE error in references below
+#  wheras "from ADCore.util import AAttributeTypes" does not
+# Pull re-used annotypes into our namespace in case we are subclassed
+AAttributeTypes = ADCore.util.AAttributeTypes
+UAttributeTypes = ADCore.util.UAttributeTypes
+AAttributeNames = ADCore.util.AAttributeNames
+UAttributeNames = ADCore.util.UAttributeNames
+UBitNames = pandablocks.util.UBitNames
+UBitValues = pandablocks.util.UBitValues
+UBitCaptures = pandablocks.util.UBitCaptures
+UPositionNames = pandablocks.util.UPositionNames
+UPositionValues = pandablocks.util.UPositionValues
+UPositionUnits = pandablocks.util.UPositionUnits
+UPositionScales = pandablocks.util.UPositionScales
+UPositionOffsets = pandablocks.util.UPositionOffsets
+UPositionCaptures = pandablocks.util.UPositionCaptures
 
 
 class SequencerTable(Table):
@@ -81,7 +96,7 @@ class SequencerTable(Table):
         self.outf2 = AOutArray(outf2)
 
 
-class DatasetBitsTable(BitsTable):
+class DatasetBitsTable(pandablocks.util.BitsTable):
     # Allow CamelCase as arguments will be serialized
     # noinspection PyPep8Naming
     def __init__(self,
@@ -97,7 +112,7 @@ class DatasetBitsTable(BitsTable):
         self.datasetType = AAttributeTypes(datasetType)
 
 
-class DatasetPositionsTable(PositionsTable):
+class DatasetPositionsTable(pandablocks.util.PositionsTable):
     # Allow CamelCase as arguments will be serialized
     # noinspection PyPep8Naming
     def __init__(self,

--- a/malcolm/modules/adUtil/parts/__init__.py
+++ b/malcolm/modules/adUtil/parts/__init__.py
@@ -1,4 +1,4 @@
-from .reframepluginpart import ReframePluginPart
+from .reframepluginpart import ReframePluginPart, APartName, AMri
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/adUtil/parts/reframepluginpart.py
+++ b/malcolm/modules/adUtil/parts/reframepluginpart.py
@@ -5,12 +5,15 @@ from malcolm.modules import ADCore, scanning, builtin
 with Anno("Sample frequency of ADC signal in Hz"):
     ASampleFreq = float
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = ADCore.parts.APartName
+AMri = ADCore.parts.AMri
 
 # We will set these attributes on the child block, so don't save them
 @builtin.util.no_save('postCount')
 class ReframePluginPart(ADCore.parts.DetectorDriverPart):
     def __init__(self, name, mri, sample_freq=10000.0):
-        # type: (ADCore.parts.APartName, ADCore.parts.AMri, ASampleFreq) -> None
+        # type: (APartName, AMri, ASampleFreq) -> None
         super(ReframePluginPart, self).__init__(name, mri)
         self.sample_freq = sample_freq
         # Hooks

--- a/malcolm/modules/adUtil/parts/reframepluginpart.py
+++ b/malcolm/modules/adUtil/parts/reframepluginpart.py
@@ -1,5 +1,6 @@
 from annotypes import Anno, add_call_types, Any
 
+from malcolm.core import PartRegistrar
 from malcolm.modules import ADCore, scanning, builtin
 
 with Anno("Sample frequency of ADC signal in Hz"):
@@ -16,8 +17,12 @@ class ReframePluginPart(ADCore.parts.DetectorDriverPart):
         # type: (APartName, AMri, ASampleFreq) -> None
         super(ReframePluginPart, self).__init__(name, mri)
         self.sample_freq = sample_freq
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(ReframePluginPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(scanning.hooks.ValidateHook, self.validate)
+        registrar.hook(scanning.hooks.ValidateHook, self.validate)
 
     @add_call_types
     def validate(self, generator):

--- a/malcolm/modules/asyn/parts/__init__.py
+++ b/malcolm/modules/asyn/parts/__init__.py
@@ -1,4 +1,5 @@
-from .asynsourceportpart import AsynSourcePortPart
+from .asynsourceportpart import AsynSourcePortPart, APartName, \
+    AMetaDescription, ARbv, AGroup
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/asyn/parts/asynsourceportpart.py
+++ b/malcolm/modules/asyn/parts/asynsourceportpart.py
@@ -7,17 +7,23 @@ from malcolm.modules import ca
 with Anno("Source Port type"):
     APortType = Port
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = ca.util.APartName
+AMetaDescription = ca.util.AMetaDescription
+ARbv = ca.util.ARbv
+AGroup = ca.util.AGroup
+
 
 class AsynSourcePortPart(Part):
     """Defines a string `Attribute` representing a asyn port that should be
     depicted as an Source Port on a Block"""
 
     def __init__(self,
-                 name,  # type: ca.util.APartName
-                 description,  # type: ca.util.AMetaDescription
-                 rbv,  # type: ca.util.ARbv
+                 name,  # type: APartName
+                 description,  # type: AMetaDescription
+                 rbv,  # type: ARbv
                  port_type,  # type: APortType
-                 group=None  # type: ca.util.AGroup
+                 group=None  # type: AGroup
                  ):
         # type: (...) -> None
         super(AsynSourcePortPart, self).__init__(name)

--- a/malcolm/modules/builtin/blocks/proxyblock.py
+++ b/malcolm/modules/builtin/blocks/proxyblock.py
@@ -1,6 +1,6 @@
 from annotypes import Any
 
-from malcolm.modules.builtin.controllers import ProxyController, AMri, AComms, \
+from ..controllers import ProxyController, AMri, AComms, \
     APublish
 
 

--- a/malcolm/modules/builtin/controllers/__init__.py
+++ b/malcolm/modules/builtin/controllers/__init__.py
@@ -1,10 +1,10 @@
 from .basiccontroller import BasicController, AMri, ADescription
-from .statefulcontroller import StatefulController
+from .statefulcontroller import StatefulController, AMri, ADescription
 from .managercontroller import ManagerController, AConfigDir, AInitialDesign, \
-    AUseGit, ATemplateDesigns
+    AUseGit, ATemplateDesigns, AMri, ADescription
 from .clientcomms import ClientComms
-from .proxycontroller import ProxyController, AComms, APublish
-from .servercomms import ServerComms
+from .proxycontroller import ProxyController, AComms, APublish, AMri
+from .servercomms import ServerComms, AMri, ADescription
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/builtin/controllers/basiccontroller.py
+++ b/malcolm/modules/builtin/controllers/basiccontroller.py
@@ -1,6 +1,10 @@
 from malcolm.core import Controller, StringMeta, AMri, ADescription, Widget
 from ..infos import LabelInfo, HealthInfo
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+AMri = AMri
+ADescription = ADescription
+
 
 class BasicController(Controller):
     """Basic Controller with Health and Title updating"""

--- a/malcolm/modules/builtin/controllers/managercontroller.py
+++ b/malcolm/modules/builtin/controllers/managercontroller.py
@@ -14,11 +14,9 @@ from malcolm.core import Unsubscribe, Subscribe, \
     TableMeta, ChoiceMeta, config_tag, \
     CAMEL_RE, camel_to_title, StringMeta
 from malcolm.core.tags import without_group_tags, Port
-from malcolm.modules.builtin.infos import PortInfo
-from malcolm.modules.builtin.util import ManagerStates
 from ..hooks import LayoutHook, LoadHook, SaveHook
-from ..infos import LayoutInfo, PartExportableInfo, PartModifiedInfo
-from ..util import LayoutTable, ExportTable
+from ..infos import LayoutInfo, PartExportableInfo, PartModifiedInfo, PortInfo
+from ..util import LayoutTable, ExportTable, ManagerStates
 from .statefulcontroller import StatefulController, AMri, ADescription
 
 if TYPE_CHECKING:

--- a/malcolm/modules/builtin/controllers/managercontroller.py
+++ b/malcolm/modules/builtin/controllers/managercontroller.py
@@ -39,6 +39,10 @@ with Anno("A directory of templates with which to initially populate designs "
           "Attribute. These cannot be saved over."):
     ATemplateDesigns = str
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+AMri = AMri
+ADescription = ADescription
+
 
 def check_git_version(required_version):
     output = subprocess.check_output(("git", "--version",))
@@ -91,7 +95,7 @@ class ManagerController(StatefulController):
         self.context_modified = {}  # type: Dict[Part, Set[str]]
         self.part_modified = {}  # type: Dict[Part, PartModifiedInfo]
         # The attributes our part has published
-        self.our_config_attributes = {}  # type: Dict[str, AttributeModel]]
+        self.our_config_attributes = {}  # type: Dict[str, AttributeModel]
         # The reportable infos we are listening for
         self.info_registry.add_reportable(
             PartModifiedInfo, self.update_modified)

--- a/malcolm/modules/builtin/controllers/proxycontroller.py
+++ b/malcolm/modules/builtin/controllers/proxycontroller.py
@@ -13,6 +13,9 @@ with Anno("Malcolm resource id of client comms"):
 with Anno("Whether to re-publish this block via server comms"):
     APublish = bool
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+AMri = AMri
+
 
 class ProxyController(BasicController):
     """Sync a local block with a given remote block"""

--- a/malcolm/modules/builtin/controllers/servercomms.py
+++ b/malcolm/modules/builtin/controllers/servercomms.py
@@ -2,6 +2,10 @@ from malcolm.core import Part
 from .statefulcontroller import StatefulController, AMri, ADescription
 from ..infos import RequestInfo
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+AMri = AMri
+ADescription = ADescription
+
 
 class ServerComms(StatefulController):
     """Abstract class for dealing with requests from outside"""

--- a/malcolm/modules/builtin/controllers/statefulcontroller.py
+++ b/malcolm/modules/builtin/controllers/statefulcontroller.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 
 ss = StatefulStates
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+AMri = AMri
+ADescription = ADescription
+
 
 class StatefulController(BasicController):
     """A controller that implements `StatefulStates`"""

--- a/malcolm/modules/builtin/controllers/statefulcontroller.py
+++ b/malcolm/modules/builtin/controllers/statefulcontroller.py
@@ -3,7 +3,7 @@ from annotypes import TYPE_CHECKING
 from malcolm.compat import OrderedDict
 from malcolm.core import Alarm, MethodModel, AttributeModel, ProcessStartHook, \
     ProcessStopHook, ChoiceMeta, Widget, Context, Part, NotWriteableError
-from malcolm.modules.builtin.util import StatefulStates
+from ..util import StatefulStates
 from .basiccontroller import BasicController, AMri, ADescription
 from ..hooks import InitHook, ResetHook, DisableHook, HaltHook
 from ..infos import HealthInfo

--- a/malcolm/modules/builtin/parts/__init__.py
+++ b/malcolm/modules/builtin/parts/__init__.py
@@ -1,13 +1,16 @@
-from .blockpart import BlockPart
-# Re-export APartName as subclasses of ChildPart may want to use it
+from .blockpart import BlockPart, APartName, AMetaDescription, AWriteable, \
+    AConfig, AGroup, AWidget
 from .childpart import APartName, ChildPart, AMri, AInitialVisibility
-from .choicepart import ChoicePart
-from .float64part import Float64Part
-from .grouppart import GroupPart
-from .helppart import HelpPart
+from .choicepart import ChoicePart, APartName, AMetaDescription, AWriteable, \
+    AConfig, AGroup, AWidget
+from .float64part import Float64Part, APartName, AMetaDescription, APrecision, \
+    AUnits, ALimitHigh, ALimitLow, AWriteable, AConfig, AGroup, AWidget
+from .grouppart import GroupPart, APartName, AMetaDescription
+from .helppart import HelpPart, AHelpUrl, APartName
 from .iconpart import IconPart, ASvg
 from .labelpart import LabelPart, ALabelValue
-from .stringpart import StringPart
+from .stringpart import StringPart, AValue, APartName, AMetaDescription, \
+    AWriteable, AConfig, AGroup, AWidget
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/builtin/parts/blockpart.py
+++ b/malcolm/modules/builtin/parts/blockpart.py
@@ -7,6 +7,14 @@ from ..util import set_tags, AWriteable, AConfig, AGroup, AWidget
 with Anno("Initial value of the created attribute"):
     AValue = str
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMetaDescription = AMetaDescription
+AWriteable = AWriteable
+AConfig = AConfig
+AGroup = AGroup
+AWidget = AWidget
+
 
 class BlockPart(Part):
     """Create a single string SinkPort for connecting to another Block"""

--- a/malcolm/modules/builtin/parts/childpart.py
+++ b/malcolm/modules/builtin/parts/childpart.py
@@ -4,12 +4,11 @@ from malcolm.compat import OrderedDict, clean_repr
 from malcolm.core import Part, Attribute, Subscribe, \
     Unsubscribe, APartName, Port, Controller, Response, \
     get_config_tag, Update, Return, Put, Request
-from malcolm.modules.builtin.hooks import AInit
 from ..infos import PortInfo, LayoutInfo, SourcePortInfo, SinkPortInfo, \
     PartExportableInfo, PartModifiedInfo
 from ..hooks import InitHook, HaltHook, ResetHook, LayoutHook, DisableHook, \
     AContext, APortMap, ALayoutTable, LoadHook, SaveHook, AStructure, \
-    ULayoutInfos
+    ULayoutInfos, AInit
 from ..util import StatefulStates, wait_for_stateful_block_init
 
 if TYPE_CHECKING:
@@ -26,6 +25,8 @@ with Anno("Whether the part is initially visible with no config loaded, None "
 with Anno("If the child is a StatefulController then this should be True"):
     AStateful = bool
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
 
 ss = StatefulStates
 

--- a/malcolm/modules/builtin/parts/childpart.py
+++ b/malcolm/modules/builtin/parts/childpart.py
@@ -3,7 +3,7 @@ from annotypes import Anno, add_call_types, TYPE_CHECKING
 from malcolm.compat import OrderedDict, clean_repr
 from malcolm.core import Part, Attribute, Subscribe, \
     Unsubscribe, APartName, Port, Controller, Response, \
-    get_config_tag, Update, Return, Put, Request
+    get_config_tag, Update, Return, Put, Request, PartRegistrar
 from ..infos import PortInfo, LayoutInfo, SourcePortInfo, SinkPortInfo, \
     PartExportableInfo, PartModifiedInfo
 from ..hooks import InitHook, HaltHook, ResetHook, LayoutHook, DisableHook, \
@@ -78,14 +78,18 @@ class ChildPart(Part):
         self.config_subscriptions = {}  # type: Dict[int, Subscribe]
         # {attr_name: PortInfo}
         self.port_infos = {}  # type: Dict[str, PortInfo]
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(ChildPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(InitHook, self.init)
-        self.register_hooked(HaltHook, self.halt)
-        self.register_hooked(LayoutHook, self.layout)
-        self.register_hooked(LoadHook, self.load)
-        self.register_hooked(SaveHook, self.save)
-        self.register_hooked(DisableHook, self.disable)
-        self.register_hooked(ResetHook, self.reset)
+        registrar.hook(InitHook, self.init)
+        registrar.hook(HaltHook, self.halt)
+        registrar.hook(LayoutHook, self.layout)
+        registrar.hook(LoadHook, self.load)
+        registrar.hook(SaveHook, self.save)
+        registrar.hook(DisableHook, self.disable)
+        registrar.hook(ResetHook, self.reset)
 
     @add_call_types
     def init(self, context):

--- a/malcolm/modules/builtin/parts/choicepart.py
+++ b/malcolm/modules/builtin/parts/choicepart.py
@@ -12,6 +12,14 @@ with Anno("Initial value of the created attribute"):
     AValue = str
 UChoices = Union[AChoices, Sequence[Enum], Sequence[str], str]
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMetaDescription = AMetaDescription
+AWriteable = AWriteable
+AConfig = AConfig
+AGroup = AGroup
+AWidget = AWidget
+
 
 class ChoicePart(Part):
     """Create a single choice Attribute on the Block"""
@@ -35,4 +43,3 @@ class ChoicePart(Part):
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         registrar.add_attribute_model(self.name, self.attr, self.writeable_func)
-

--- a/malcolm/modules/builtin/parts/float64part.py
+++ b/malcolm/modules/builtin/parts/float64part.py
@@ -7,6 +7,18 @@ from ..util import set_tags, AWriteable, AConfig, AGroup, AWidget
 with Anno("Initial value of the created attribute"):
     AValue = float
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMetaDescription = AMetaDescription
+APrecision = APrecision
+AUnits = AUnits
+ALimitHigh = ALimitHigh
+ALimitLow = ALimitLow
+AWriteable = AWriteable
+AConfig = AConfig
+AGroup = AGroup
+AWidget = AWidget
+
 
 class Float64Part(Part):
     """Create a single float64 Attribute on the Block"""

--- a/malcolm/modules/builtin/parts/grouppart.py
+++ b/malcolm/modules/builtin/parts/grouppart.py
@@ -2,6 +2,10 @@ from malcolm.core import Part, PartRegistrar, ChoiceMeta, APartName, \
     AMetaDescription, Widget
 from ..util import set_tags
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMetaDescription = AMetaDescription
+
 
 class GroupPart(Part):
     """Part representing a GUI group other Attributes attach to"""

--- a/malcolm/modules/builtin/parts/helppart.py
+++ b/malcolm/modules/builtin/parts/helppart.py
@@ -7,6 +7,9 @@ from ..util import set_tags
 with Anno("The URL that gives some help documentation for this Block"):
     AHelpUrl = str
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+
 
 class HelpPart(Part):
     """Part representing a link to some help documentation for the GUI"""

--- a/malcolm/modules/builtin/parts/stringpart.py
+++ b/malcolm/modules/builtin/parts/stringpart.py
@@ -7,6 +7,14 @@ from ..util import set_tags, AWriteable, AConfig, AGroup, AWidget
 with Anno("Initial value of the created attribute"):
     AValue = str
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMetaDescription = AMetaDescription
+AWriteable = AWriteable
+AConfig = AConfig
+AGroup = AGroup
+AWidget = AWidget
+
 
 class StringPart(Part):
     """Create a single string Attribute on the Block"""

--- a/malcolm/modules/ca/__init__.py
+++ b/malcolm/modules/ca/__init__.py
@@ -1,3 +1,3 @@
 from . import util, parts
-from util import APartName, AMetaDescription, AWidget, AGroup, \
+from .util import APartName, AMetaDescription, AWidget, AGroup, \
     AConfig, ASinkPort

--- a/malcolm/modules/ca/__init__.py
+++ b/malcolm/modules/ca/__init__.py
@@ -1,1 +1,3 @@
 from . import util, parts
+from util import APartName, AMetaDescription, AWidget, AGroup, \
+    AConfig, ASinkPort

--- a/malcolm/modules/ca/parts/caactionpart.py
+++ b/malcolm/modules/ca/parts/caactionpart.py
@@ -45,13 +45,14 @@ class CAActionPart(Part):
         self.message_pv = message_pv
         self.value = value
         self.wait = wait
-        # Hooks
-        self.register_hooked((builtin.hooks.InitHook,
-                              builtin.hooks.ResetHook), self.connect_pvs)
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         super(CAActionPart, self).setup(registrar)
+        # Hooks
+        registrar.hook((builtin.hooks.InitHook,
+                        builtin.hooks.ResetHook), self.connect_pvs)
+        # Methods
         registrar.add_method_model(self.caput, self.name, self.description)
 
     def connect_pvs(self):

--- a/malcolm/modules/ca/util.py
+++ b/malcolm/modules/ca/util.py
@@ -4,9 +4,7 @@ from annotypes import Anno, Array, TYPE_CHECKING
 
 from malcolm.core import sleep, VMeta, Alarm, AlarmStatus, TimeStamp, \
     Loggable, APartName, AMetaDescription, Hook, PartRegistrar, DEFAULT_TIMEOUT
-from malcolm.modules.builtin.util import set_tags, AWidget, AGroup, AConfig, \
-    ASinkPort
-from malcolm.modules.builtin.hooks import InitHook, ResetHook, DisableHook
+from malcolm.modules import builtin
 
 if TYPE_CHECKING:
     from typing import Callable, Any, Union, Type, Sequence, Optional, List
@@ -18,6 +16,10 @@ if TYPE_CHECKING:
 # Store them here for re-export
 APartName = APartName
 AMetaDescription = AMetaDescription
+AWidget = builtin.util.AWidget
+AGroup = builtin.util.AGroup
+AConfig = builtin.util.AConfig
+ASinkPort = builtin.util.ASinkPort
 
 
 class CatoolsDeferred(object):
@@ -63,7 +65,8 @@ class CABase(Loggable):
                  ):
         # type: (...) -> None
         self.writeable = writeable
-        set_tags(meta, writeable, config, group, widget, sink_port)
+        builtin.util.set_tags(
+            meta, writeable, config, group, widget, sink_port)
         self.datatype = datatype
         self.min_delta = min_delta
         self.timeout = timeout
@@ -116,8 +119,9 @@ class CABase(Loggable):
         else:
             writeable_func = None
         registrar.add_attribute_model(name, self.attr, writeable_func)
-        register_hooked(DisableHook, self.disconnect)
-        register_hooked((InitHook, ResetHook), self.reconnect)
+        register_hooked(builtin.hooks.DisableHook, self.disconnect)
+        register_hooked((builtin.hooks.InitHook, builtin.hooks.ResetHook),
+                        self.reconnect)
 
     def _monitor_callback(self, value, value_index=None):
         now = time.time()

--- a/malcolm/modules/demo/parts/filewritepart.py
+++ b/malcolm/modules/demo/parts/filewritepart.py
@@ -66,9 +66,9 @@ class FileWritePart(Part):
                   completed_steps,  # type: scanning.hooks.ACompletedSteps
                   steps_to_do,  # type: scanning.hooks.AStepsToDo
                   generator,  # type: scanning.hooks.AGenerator
-                  fileDir,  # type: scanning.util.AFileDir
-                  formatName="det",  # type: scanning.util.AFormatName
-                  fileTemplate="%s.h5",  # type: scanning.util.AFileTemplate
+                  fileDir,  # type: scanning.hooks.AFileDir
+                  formatName="det",  # type: scanning.hooks.AFormatName
+                  fileTemplate="%s.h5",  # type: scanning.hooks.AFileTemplate
                   ):
         # type: (...) -> scanning.hooks.UInfos
         """On `ConfigureHook` create HDF file with datasets"""

--- a/malcolm/modules/pandablocks/__init__.py
+++ b/malcolm/modules/pandablocks/__init__.py
@@ -1,1 +1,1 @@
-from . import controllers, parts
+from . import controllers, parts, util

--- a/malcolm/modules/pandablocks/controllers/__init__.py
+++ b/malcolm/modules/pandablocks/controllers/__init__.py
@@ -1,6 +1,8 @@
 from .pandamanagercontroller import PandAManagerController, \
     AMri, AConfigDir, AHostname, APort, AInitialDesign, ADescription, \
     AUseGit, ATemplateDesigns, APollPeriod
+from .pandablockcontroller import PandABlockController, AClient, ADocUrlBase, \
+    ABlockName
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/pandablocks/controllers/pandablockcontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandablockcontroller.py
@@ -12,7 +12,7 @@ from ..parts.pandaluticonpart import PandALutIconPart
 from ..parts.pandaactionpart import PandAActionPart
 from ..parts.pandafieldpart import PandAFieldPart
 from ..parts.pandatablepart import PandATablePart
-from .. import util
+from ..util import SVG_DIR, AClient, ADocUrlBase, ABlockName
 from ..pandablocksclient import BlockData, FieldData
 
 if TYPE_CHECKING:
@@ -26,9 +26,9 @@ with Anno("The BlockData object showing the fields of the Block"):
     ABlockData = BlockData
 
 # Pull re-used annotypes into our namespace in case we are subclassed
-AClient = util.AClient
-ADocUrlBase = util.ADocUrlBase
-ABlockName = util.ABlockName
+AClient = AClient
+ADocUrlBase = ADocUrlBase
+ABlockName = ABlockName
 
 
 def make_meta(subtyp, description, tags, writeable=True, labels=None):
@@ -123,7 +123,7 @@ class PandABlockController(builtin.controllers.BasicController):
         # type: () -> PandAIconPart
         block_type = self.block_name.rstrip("0123456789")
         block_number = self.block_name[len(block_type):]
-        svg_path = os.path.join(util.SVG_DIR, block_type + ".svg")
+        svg_path = os.path.join(SVG_DIR, block_type + ".svg")
         if block_type == "LUT":
             icon_cls = PandALutIconPart
         else:

--- a/malcolm/modules/pandablocks/controllers/pandablockcontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandablockcontroller.py
@@ -12,7 +12,7 @@ from ..parts.pandaluticonpart import PandALutIconPart
 from ..parts.pandaactionpart import PandAActionPart
 from ..parts.pandafieldpart import PandAFieldPart
 from ..parts.pandatablepart import PandATablePart
-from ..util import AClient, ADocUrlBase, SVG_DIR, ABlockName
+from .. import util
 from ..pandablocksclient import BlockData, FieldData
 
 if TYPE_CHECKING:
@@ -24,6 +24,11 @@ with Anno("Prefix to put on the beginning of the Block Name to make MRI"):
     AMriPrefix = str
 with Anno("The BlockData object showing the fields of the Block"):
     ABlockData = BlockData
+
+# Pull re-used annotypes into our namespace in case we are subclassed
+AClient = util.AClient
+ADocUrlBase = util.ADocUrlBase
+ABlockName = util.ABlockName
 
 
 def make_meta(subtyp, description, tags, writeable=True, labels=None):
@@ -118,7 +123,7 @@ class PandABlockController(builtin.controllers.BasicController):
         # type: () -> PandAIconPart
         block_type = self.block_name.rstrip("0123456789")
         block_number = self.block_name[len(block_type):]
-        svg_path = os.path.join(SVG_DIR, block_type + ".svg")
+        svg_path = os.path.join(util.SVG_DIR, block_type + ".svg")
         if block_type == "LUT":
             icon_cls = PandALutIconPart
         else:

--- a/malcolm/modules/pandablocks/parts/__init__.py
+++ b/malcolm/modules/pandablocks/parts/__init__.py
@@ -1,1 +1,3 @@
-# No imports as nothing should be instantiated from YAML
+# nothing should be instantiated from YAML but pandabussespart is imported
+# from ADPandaBlocks
+import pandabussespart

--- a/malcolm/modules/pandablocks/parts/__init__.py
+++ b/malcolm/modules/pandablocks/parts/__init__.py
@@ -1,3 +1,3 @@
 # nothing should be instantiated from YAML but pandabussespart is imported
 # from ADPandaBlocks
-import pandabussespart
+from . import pandabussespart

--- a/malcolm/modules/pandablocks/parts/__init__.py
+++ b/malcolm/modules/pandablocks/parts/__init__.py
@@ -1,3 +1,3 @@
 # nothing should be instantiated from YAML but pandabussespart is imported
 # from ADPandaBlocks
-from . import pandabussespart
+from .pandabussespart import PandABussesPart

--- a/malcolm/modules/pandablocks/parts/pandafieldpart.py
+++ b/malcolm/modules/pandablocks/parts/pandafieldpart.py
@@ -2,7 +2,7 @@ from annotypes import Anno, Any
 
 from malcolm.core import Part, snake_to_camel, BooleanMeta, VMeta, \
     PartRegistrar, TimeStamp, Alarm
-from malcolm.modules.pandablocks.pandablocksclient import PandABlocksClient
+from ..pandablocksclient import PandABlocksClient
 
 
 with Anno("Client for setting and getting field"):

--- a/malcolm/modules/pmac/parts/__init__.py
+++ b/malcolm/modules/pmac/parts/__init__.py
@@ -1,10 +1,11 @@
-from .compoundmotorsinkportspart import CompoundMotorSinkPortsPart
-from .cssourceportspart import CSSourcePortsPart
-from .cspart import CSPart
-from .pmacchildpart import PmacChildPart
+from .compoundmotorsinkportspart import CompoundMotorSinkPortsPart, \
+    APartName, ARbv, AGroup
+from .cssourceportspart import CSSourcePortsPart, APartName, ARbv, AGroup
+from .cspart import CSPart, AMri
+from .pmacchildpart import PmacChildPart, AMri, APartName
 from .pmacstatuspart import PmacStatusPart
-from .pmactrajectorypart import PmacTrajectoryPart
-from .rawmotorsinkportspart import RawMotorSinkPortsPart
+from .pmactrajectorypart import PmacTrajectoryPart, AMri, APartName
+from .rawmotorsinkportspart import RawMotorSinkPortsPart, AGroup
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/pmac/parts/compoundmotorsinkportspart.py
+++ b/malcolm/modules/pmac/parts/compoundmotorsinkportspart.py
@@ -23,14 +23,14 @@ class CompoundMotorSinkPortsPart(Part):
         self.attr = meta.create_attribute_model()
         # Subscriptions
         self.monitor = None
-        # Hooks
-        self.register_hooked(builtin.hooks.DisableHook, self.disconnect)
-        self.register_hooked((builtin.hooks.InitHook,
-                              builtin.hooks.ResetHook), self.reconnect)
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         registrar.add_attribute_model(self.name, self.attr)
+        # Hooks
+        registrar.hook(builtin.hooks.DisableHook, self.disconnect)
+        registrar.hook((builtin.hooks.InitHook,
+                        builtin.hooks.ResetHook), self.reconnect)
 
     def reconnect(self):
         # release old monitors

--- a/malcolm/modules/pmac/parts/compoundmotorsinkportspart.py
+++ b/malcolm/modules/pmac/parts/compoundmotorsinkportspart.py
@@ -4,13 +4,18 @@ from malcolm.core import Part, PartRegistrar, StringMeta, Port, Alarm
 from malcolm.modules import ca, builtin
 from ..util import CS_AXIS_NAMES
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = ca.util.APartName
+ARbv = ca.util.ARbv
+AGroup = ca.util.AGroup
+
 
 class CompoundMotorSinkPortsPart(Part):
     """Defines a string `Attribute` representing the CS this compound motor
     is permanently assigned to by reading its motor record OUT link"""
 
     def __init__(self, name, rbv, group=None):
-        # type: (ca.util.APartName, ca.util.ARbv, ca.util.AGroup) -> None
+        # type: (APartName, ARbv, AGroup) -> None
         super(CompoundMotorSinkPortsPart, self).__init__(name)
         meta = StringMeta("CS Axis")
         builtin.util.set_tags(meta, group=group, sink_port=Port.MOTOR)

--- a/malcolm/modules/pmac/parts/cspart.py
+++ b/malcolm/modules/pmac/parts/cspart.py
@@ -2,7 +2,6 @@ from annotypes import add_call_types, Anno
 
 from malcolm.core import DEFAULT_TIMEOUT, PartRegistrar
 from malcolm.modules import builtin
-from malcolm.modules.builtin.parts import ChildPart
 from ..util import CS_AXIS_NAMES
 
 
@@ -13,10 +12,13 @@ with Anno("Motor position to move to in EGUs"):
 with Anno("Time to take to perform move"):
     AMoveTime = float
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+AMri = builtin.parts.AMri
 
-class CSPart(ChildPart):
+
+class CSPart(builtin.parts.ChildPart):
     def __init__(self, mri, cs):
-        # type: (builtin.parts.AMri, ACS) -> None
+        # type: (AMri, ACS) -> None
         super(CSPart, self).__init__("CS%d" % cs, mri, initial_visibility=True)
         self.cs = cs
 

--- a/malcolm/modules/pmac/parts/cssourceportspart.py
+++ b/malcolm/modules/pmac/parts/cssourceportspart.py
@@ -4,13 +4,18 @@ from malcolm.core import Part, PartRegistrar, StringMeta, Port
 from malcolm.modules import ca
 from ..util import CS_AXIS_NAMES
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = ca.util.APartName
+ARbv = ca.util.ARbv
+AGroup = ca.util.AGroup
+
 
 class CSSourcePortsPart(Part):
     """Defines a string `Attribute` for the CS Port name, and 10 Source Ports
     for the axes A-Z and I for the axis assignments"""
 
     def __init__(self, name, rbv, group=None):
-        # type: (ca.util.APartName, ca.util.ARbv, ca.util.AGroup) -> None
+        # type: (APartName, ARbv, AGroup) -> None
         super(CSSourcePortsPart, self).__init__(name)
         self.meta = StringMeta("CS Port name")
         # This gives the port name

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -7,7 +7,7 @@ import numpy as np
 from annotypes import add_call_types, TYPE_CHECKING
 from scanpointgenerator import CompoundGenerator
 
-from malcolm.core import Future, Block
+from malcolm.core import Future, Block, PartRegistrar
 from malcolm.modules import builtin, scanning
 from ..infos import MotorInfo
 from ..util import cs_axis_mapping, points_joined, point_velocities, MIN_TIME, \
@@ -76,16 +76,20 @@ class PmacChildPart(builtin.parts.ChildPart):
         self.profile = {}
         # Stored generator for positions
         self.generator = None  # type: CompoundGenerator
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(PmacChildPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(scanning.hooks.ValidateHook, self.validate)
-        self.register_hooked(scanning.hooks.PreConfigureHook, self.reload)
-        self.register_hooked((scanning.hooks.ConfigureHook,
-                              scanning.hooks.PostRunArmedHook,
-                              scanning.hooks.SeekHook), self.configure)
-        self.register_hooked((scanning.hooks.RunHook,
-                              scanning.hooks.ResumeHook), self.run)
-        self.register_hooked((scanning.hooks.AbortHook,
-                              scanning.hooks.PauseHook), self.abort)
+        registrar.hook(scanning.hooks.ValidateHook, self.validate)
+        registrar.hook(scanning.hooks.PreConfigureHook, self.reload)
+        registrar.hook((scanning.hooks.ConfigureHook,
+                        scanning.hooks.PostRunArmedHook,
+                        scanning.hooks.SeekHook), self.configure)
+        registrar.hook((scanning.hooks.RunHook,
+                        scanning.hooks.ResumeHook), self.run)
+        registrar.hook((scanning.hooks.AbortHook,
+                        scanning.hooks.PauseHook), self.abort)
 
     @add_call_types
     def reset(self, context):

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -2,7 +2,6 @@
 from __future__ import division
 
 import re
-import time
 
 import numpy as np
 from annotypes import add_call_types, TYPE_CHECKING
@@ -10,7 +9,6 @@ from scanpointgenerator import CompoundGenerator
 
 from malcolm.core import Future, Block
 from malcolm.modules import builtin, scanning
-from malcolm.modules.scanning.infos import MinTurnaroundInfo
 from ..infos import MotorInfo
 from ..util import cs_axis_mapping, points_joined, point_velocities, MIN_TIME, \
     profile_between_points
@@ -46,11 +44,15 @@ PROFILE_POINTS = 10000
 # 80 char line lengths...
 AIV = builtin.parts.AInitialVisibility
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = builtin.parts.APartName
+AMri = builtin.parts.AMri
+
 
 class PmacChildPart(builtin.parts.ChildPart):
     def __init__(self,
-                 name,  # type: builtin.parts.APartName
-                 mri,  # type: builtin.parts.AMri
+                 name,  # type: APartName
+                 mri,  # type: AMri
                  initial_visibility=None  # type: AIV
                  ):
         # type: (...) -> None
@@ -172,7 +174,7 @@ class PmacChildPart(builtin.parts.ChildPart):
         # Store if we need to output triggers
         self.output_triggers = child.outputTriggers.value
         # See if there is a minimum turnaround
-        infos = MinTurnaroundInfo.filter_values(part_info)
+        infos = scanning.infos.MinTurnaroundInfo.filter_values(part_info)
         if infos:
             assert len(infos) == 1, \
                 "Expected 0 or 1 MinTurnaroundInfos, got %d" % len(infos)

--- a/malcolm/modules/pmac/parts/pmactrajectorypart.py
+++ b/malcolm/modules/pmac/parts/pmactrajectorypart.py
@@ -22,6 +22,10 @@ with Anno("Which user program to run for each point"):
 with Anno("The position the axis should be at for each point in the scan"):
     ADemandTrajectory = Array[np.float64]
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = builtin.parts.APartName
+AMri = builtin.parts.AMri
+
 
 def _zeros_or_right_length(array, num_points):
     if array is None:
@@ -41,8 +45,8 @@ def _zeros_or_right_length(array, num_points):
 @builtin.util.no_save("positions%s" % x for x in CS_AXIS_NAMES)
 class PmacTrajectoryPart(builtin.parts.ChildPart):
     def __init__(self,
-                 name,  # type: builtin.parts.APartName
-                 mri,  # type: builtin.parts.AMri
+                 name,  # type: APartName
+                 mri,  # type: AMri
                  initial_output_triggers=True  # type: AOutputTriggers
                  ):
         # type: (...) -> None

--- a/malcolm/modules/pmac/parts/rawmotorsinkportspart.py
+++ b/malcolm/modules/pmac/parts/rawmotorsinkportspart.py
@@ -34,15 +34,15 @@ class RawMotorSinkPortsPart(Part):
         self.port = None
         self.axis = None
         self.port_choices = []
-        # Hooks
-        self.register_hooked(builtin.hooks.DisableHook, self.disconnect)
-        self.register_hooked((builtin.hooks.InitHook,
-                              builtin.hooks.ResetHook), self.reconnect)
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         registrar.add_attribute_model("pmac", self.pmac_attr)
         registrar.add_attribute_model("cs", self.cs_attr, self.caput)
+        # Hooks
+        registrar.hook(builtin.hooks.DisableHook, self.disconnect)
+        registrar.hook((builtin.hooks.InitHook,
+                        builtin.hooks.ResetHook), self.reconnect)
 
     def reconnect(self):
         # release old monitors

--- a/malcolm/modules/pmac/parts/rawmotorsinkportspart.py
+++ b/malcolm/modules/pmac/parts/rawmotorsinkportspart.py
@@ -3,10 +3,13 @@ from annotypes import Anno
 from malcolm.core import Part, PartRegistrar, ChoiceMeta, Port, Alarm, \
     StringMeta
 from malcolm.modules import ca, builtin
-from malcolm.modules.pmac.util import CS_AXIS_NAMES
+from ..util import CS_AXIS_NAMES
 
 with Anno("PV prefix for CSPort and CSAxis records"):
     APvPrefix = str
+
+# Pull re-used annotypes into our namespace in case we are subclassed
+AGroup = ca.util.AGroup
 
 
 class RawMotorSinkPortsPart(Part):

--- a/malcolm/modules/profiling/parts/profilingviewerpart.py
+++ b/malcolm/modules/profiling/parts/profilingviewerpart.py
@@ -5,8 +5,7 @@ from tornado.options import options
 from plop.viewer import IndexHandler, ViewFlatHandler
 
 from malcolm.core import Part, APartName
-from malcolm.modules.web.hooks import ReportHandlersHook
-from malcolm.modules.web.infos import HandlerInfo
+from malcolm.modules import web
 from malcolm.compat import get_profiler_dir
 
 
@@ -34,10 +33,10 @@ class ProfilingViewerPart(Part):
         super(ProfilingViewerPart, self).__init__(name)
         options.datadir = get_profiler_dir()
         # Hooks
-        self.register_hooked(ReportHandlersHook, self.report_handlers)
+        self.register_hooked(web.hooks.ReportHandlersHook, self.report_handlers)
 
     def report_handlers(self):
         infos = [
-            HandlerInfo("/%s" % self.name, MalcolmIndexHandler),
-            HandlerInfo("/view", MalcolmViewHandler)]
+            web.infos.HandlerInfo("/%s" % self.name, MalcolmIndexHandler),
+            web.infos.HandlerInfo("/view", MalcolmViewHandler)]
         return infos

--- a/malcolm/modules/profiling/parts/profilingviewerpart.py
+++ b/malcolm/modules/profiling/parts/profilingviewerpart.py
@@ -4,7 +4,7 @@ import inspect
 from tornado.options import options
 from plop.viewer import IndexHandler, ViewFlatHandler
 
-from malcolm.core import Part, APartName
+from malcolm.core import Part, APartName, PartRegistrar
 from malcolm.modules import web
 from malcolm.compat import get_profiler_dir
 
@@ -32,8 +32,12 @@ class ProfilingViewerPart(Part):
         # type: (APartName) -> None
         super(ProfilingViewerPart, self).__init__(name)
         options.datadir = get_profiler_dir()
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(ProfilingViewerPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(web.hooks.ReportHandlersHook, self.report_handlers)
+        registrar.hook(web.hooks.ReportHandlersHook, self.report_handlers)
 
     def report_handlers(self):
         infos = [

--- a/malcolm/modules/pva/controllers/pvaclientcomms.py
+++ b/malcolm/modules/pva/controllers/pvaclientcomms.py
@@ -4,7 +4,7 @@ from p4p.nt import NTURI
 from p4p.client.cothread import Context, Subscription
 from annotypes import TYPE_CHECKING
 
-from malcolm.modules.builtin.controllers import ClientComms
+from malcolm.modules import builtin
 from malcolm.core import Queue, Model, DEFAULT_TIMEOUT, BlockMeta, \
     BlockModel, Alarm
 from .pvaconvert import convert_value_to_dict, convert_to_type_tuple_value, Type
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from typing import Set, Dict
 
 
-class PvaClientComms(ClientComms):
+class PvaClientComms(builtin.controllers.ClientComms):
     """A class for a client to communicate with the server"""
 
     _monitors = None

--- a/malcolm/modules/scanning/controllers/runnablecontroller.py
+++ b/malcolm/modules/scanning/controllers/runnablecontroller.py
@@ -5,9 +5,7 @@ from malcolm.core import AbortedError, Queue, Context, TimeoutError, AMri, \
     NumberMeta, Widget, Part, DEFAULT_TIMEOUT, Table
 from malcolm.compat import OrderedDict
 from malcolm.core.models import MapMeta, MethodMeta, TableMeta
-from malcolm.modules.builtin.controllers import ManagerController, \
-    AConfigDir, AInitialDesign, ADescription, AUseGit, ATemplateDesigns
-from malcolm.modules.builtin.hooks import ResetHook
+from malcolm.modules import builtin
 from ..infos import ParameterTweakInfo, RunProgressInfo, ConfigureParamsInfo
 from ..util import RunnableStates, AGenerator, AAxesToMove, ConfigureParams
 from ..hooks import ConfigureHook, ValidateHook, PostConfigureHook, \
@@ -26,6 +24,13 @@ with Anno("The validated configure parameters"):
     AConfigureParams = ConfigureParams
 with Anno("Step to mark as the last completed step, -1 for current"):
     ALastGoodStep = int
+
+# Pull re-used annotypes into our namespace in case we are subclassed
+AConfigDir = builtin.controllers.AConfigDir
+AInitialDesign = builtin.controllers.AInitialDesign
+ADescription = builtin.controllers.ADescription
+AUseGit = builtin.controllers.AUseGit
+ATemplateDesigns = builtin.controllers.ATemplateDesigns
 
 
 def get_steps_per_run(generator, axes_to_move):
@@ -119,7 +124,7 @@ def merge_non_writeable_table(default, supplied, non_writeable):
     return table
 
 
-class RunnableController(ManagerController):
+class RunnableController(builtin.controllers.ManagerController):
     """RunnableDevice implementer that also exposes GUI for child parts"""
     # The state_set that this controller implements
     state_set = ss()
@@ -363,7 +368,8 @@ class RunnableController(ManagerController):
         if state == ss.FINISHED:
             # If we were finished then do a reset before configuring
             self.run_hooks(
-                ResetHook(p, c) for p, c in self.create_part_contexts().items())
+                builtin.hooks.ResetHook(p, c) for p, c in
+                self.create_part_contexts().items())
         # Clear out any old part contexts now rather than letting gc do it
         for context in self.part_contexts.values():
             context.unsubscribe_all()

--- a/malcolm/modules/scanning/controllers/runnablecontroller.py
+++ b/malcolm/modules/scanning/controllers/runnablecontroller.py
@@ -7,10 +7,11 @@ from malcolm.compat import OrderedDict
 from malcolm.core.models import MapMeta, MethodMeta, TableMeta
 from malcolm.modules import builtin
 from ..infos import ParameterTweakInfo, RunProgressInfo, ConfigureParamsInfo
-from ..util import RunnableStates, AGenerator, AAxesToMove, ConfigureParams
+from ..util import RunnableStates, AGenerator, ConfigureParams
 from ..hooks import ConfigureHook, ValidateHook, PostConfigureHook, \
     RunHook, PostRunArmedHook, PostRunReadyHook, ResumeHook, ReportStatusHook, \
-    AbortHook, PauseHook, SeekHook, ControllerHook, PreConfigureHook
+    AbortHook, PauseHook, SeekHook, ControllerHook, PreConfigureHook, \
+    AAxesToMove
 
 if TYPE_CHECKING:
     from typing import Dict, Tuple, List, Iterable, Type, Callable

--- a/malcolm/modules/scanning/hooks.py
+++ b/malcolm/modules/scanning/hooks.py
@@ -1,11 +1,13 @@
-from annotypes import Mapping, Sequence, Anno, Array, Union, Any, \
-    TYPE_CHECKING, NO_DEFAULT
+from annotypes import Anno, Any, Array, Mapping, TYPE_CHECKING, NO_DEFAULT, \
+    Sequence, Union
+
+from scanpointgenerator import CompoundGenerator
+from .infos import ParameterTweakInfo, Info
 
 from malcolm.compat import OrderedDict
 from malcolm.core import VMeta
 from malcolm.modules import builtin
-from .infos import ParameterTweakInfo, Info, ConfigureParamsInfo
-from .util import AGenerator, AAxesToMove
+from .infos import ConfigureParamsInfo
 
 if TYPE_CHECKING:
     from typing import Dict, Callable
@@ -14,16 +16,32 @@ with Anno("The Infos returned from other Parts"):
     APartInfo = Mapping[str, Array[Info]]
 with Anno("Infos about current Part status to be passed to other parts"):
     AInfos = Array[Info]
+
+with Anno("Generator instance providing specification for scan"):
+    AGenerator = CompoundGenerator
+with Anno("List of axes in inner dimension of generator that should be moved"):
+    AAxesToMove = Array[str]
+UAxesToMove = Union[AAxesToMove, Sequence[str]]
 with Anno("Parameters that need to be changed to make them compatible"):
     AParameterTweakInfos = Array[ParameterTweakInfo]
 UInfos = Union[AInfos, Sequence[Info], Info, None]
 UParameterTweakInfos = Union[AParameterTweakInfos, Sequence[ParameterTweakInfo],
                              ParameterTweakInfo, None]
+with Anno("Directory to write data to"):
+    AFileDir = str
+with Anno("Argument for fileTemplate, normally filename without extension"):
+    AFormatName = str
+with Anno("""Printf style template to generate filename relative to fileDir.
+Arguments are:
+  1) %s: the value of formatName"""):
+    AFileTemplate = str
+with Anno("The demand exposure time of this scan, 0 for the maximum possible"):
+    AExposure = float
 
 # Pull re-used annotypes into our namespace in case we are subclassed
 APart = builtin.hooks.APart
 AContext = builtin.hooks.AContext
-# also bring in superclass which subclasses may refer to
+# also bring in superclass which a subclasses may refer to
 ControllerHook = builtin.hooks.ControllerHook
 
 

--- a/malcolm/modules/scanning/hooks.py
+++ b/malcolm/modules/scanning/hooks.py
@@ -3,7 +3,7 @@ from annotypes import Mapping, Sequence, Anno, Array, Union, Any, \
 
 from malcolm.compat import OrderedDict
 from malcolm.core import VMeta
-from malcolm.modules.builtin.hooks import ControllerHook, APart, AContext
+from malcolm.modules import builtin
 from .infos import ParameterTweakInfo, Info, ConfigureParamsInfo
 from .util import AGenerator, AAxesToMove
 
@@ -19,6 +19,12 @@ with Anno("Parameters that need to be changed to make them compatible"):
 UInfos = Union[AInfos, Sequence[Info], Info, None]
 UParameterTweakInfos = Union[AParameterTweakInfos, Sequence[ParameterTweakInfo],
                              ParameterTweakInfo, None]
+
+# Pull re-used annotypes into our namespace in case we are subclassed
+APart = builtin.hooks.APart
+AContext = builtin.hooks.AContext
+# also bring in superclass which subclasses may refer to
+ControllerHook = builtin.hooks.ControllerHook
 
 
 class ValidateHook(ControllerHook[UParameterTweakInfos]):

--- a/malcolm/modules/scanning/infos.py
+++ b/malcolm/modules/scanning/infos.py
@@ -1,10 +1,26 @@
+from enum import Enum
+
 from annotypes import TYPE_CHECKING
 
 from malcolm.core import Info, VMeta
-from .util import DatasetType
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List
+
+
+class DatasetType(Enum):
+    """NeXus type of a produced dataset"""
+    #: Detector data, like the 2D data from an imaging detector
+    PRIMARY = "primary"
+    #: Calculated from detector data, like the sum of each frame
+    SECONDARY = "secondary"
+    #: Data that only makes sense when considered with detector data, like a
+    #: measure of beam current with an ion chamber
+    MONITOR = "monitor"
+    #: The demand positions of an axis as specified by the generator
+    POSITION_SET = "position_set"
+    #: The readback positions of an axis that moves during the sacn
+    POSITION_VALUE = "position_value"
 
 
 class ParameterTweakInfo(Info):

--- a/malcolm/modules/scanning/parts/__init__.py
+++ b/malcolm/modules/scanning/parts/__init__.py
@@ -1,5 +1,6 @@
 from .datasettablepart import DatasetTablePart
-from .detectorchildpart import DetectorChildPart
+from .detectorchildpart import DetectorChildPart, AMri, ADetectorTable, \
+    AInitialVisibility, APartName
 from .simultaneousaxespart import SimultaneousAxesPart, USimultaneousAxes
 
 # Expose a nice namespace

--- a/malcolm/modules/scanning/parts/datasettablepart.py
+++ b/malcolm/modules/scanning/parts/datasettablepart.py
@@ -1,6 +1,6 @@
 from annotypes import add_call_types
 
-from malcolm.core import Part, PartRegistrar, APartName, TableMeta
+from malcolm.core import Part, PartRegistrar, TableMeta, AttributeModel
 from ..infos import DatasetProducedInfo
 from ..util import DatasetTable
 from ..hooks import PostConfigureHook, APartInfo
@@ -9,15 +9,13 @@ from ..hooks import PostConfigureHook, APartInfo
 class DatasetTablePart(Part):
     """Exposes an Attribute that reports the datasets that will be written
     during a scan"""
-    def __init__(self, name):
-        # type: (APartName) -> None
-        super(DatasetTablePart, self).__init__(name)
-        self.datasets = TableMeta.from_table(
-            DatasetTable, "Datasets produced in HDF file"
-        ).create_attribute_model()
+    datasets = None  # type: AttributeModel
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
+        self.datasets = TableMeta.from_table(
+            DatasetTable, "Datasets produced in HDF file"
+        ).create_attribute_model()
         registrar.add_attribute_model("datasets", self.datasets)
         # Hooks
         registrar.hook(PostConfigureHook, self.post_configure)

--- a/malcolm/modules/scanning/parts/datasettablepart.py
+++ b/malcolm/modules/scanning/parts/datasettablepart.py
@@ -15,11 +15,12 @@ class DatasetTablePart(Part):
         self.datasets = TableMeta.from_table(
             DatasetTable, "Datasets produced in HDF file"
         ).create_attribute_model()
-        self.register_hooked(PostConfigureHook, self.post_configure)
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         registrar.add_attribute_model("datasets", self.datasets)
+        # Hooks
+        registrar.hook(PostConfigureHook, self.post_configure)
 
     @add_call_types
     def post_configure(self, part_info):

--- a/malcolm/modules/scanning/parts/detectorchildpart.py
+++ b/malcolm/modules/scanning/parts/detectorchildpart.py
@@ -42,18 +42,18 @@ class DetectorChildPart(builtin.parts.ChildPart):
         self.frames_per_step = 0
         # Stored between runs
         self.run_future = None  # type: Future
-        # Hooks
-        self.register_hooked(ValidateHook, self.validate)
-        self.register_hooked(PreConfigureHook, self.reload)
-        self.register_hooked(ConfigureHook, self.configure)
-        self.register_hooked((RunHook, ResumeHook), self.run)
-        self.register_hooked((PostRunArmedHook, PostRunReadyHook),
-                             self.post_run)
-        self.register_hooked(SeekHook, self.seek)
-        self.register_hooked(AbortHook, self.abort)
 
     def setup(self, registrar):
         super(DetectorChildPart, self).setup(registrar)
+        # Hooks
+        registrar.hook(ValidateHook, self.validate)
+        registrar.hook(PreConfigureHook, self.reload)
+        registrar.hook(ConfigureHook, self.configure)
+        registrar.hook((RunHook, ResumeHook), self.run)
+        registrar.hook((PostRunArmedHook, PostRunReadyHook),
+                             self.post_run)
+        registrar.hook(SeekHook, self.seek)
+        registrar.hook(AbortHook, self.abort)
         # Tell the controller to expose some extra configure parameters
         configure_info = ConfigureHook.create_info(self.configure)
         # Override the detector table defaults and writeable

--- a/malcolm/modules/scanning/parts/detectorchildpart.py
+++ b/malcolm/modules/scanning/parts/detectorchildpart.py
@@ -1,9 +1,9 @@
 from annotypes import add_call_types, Anno, Any, TYPE_CHECKING, stringify_error
 
-from malcolm.core import BadValueError, APartName ,Future, Put, Request
-from malcolm.modules.scanning.infos import DatasetProducedInfo
-from malcolm.modules.builtin.parts import ChildPart, AMri, AInitialVisibility
-from malcolm.modules.scanning.hooks import UInfos
+from malcolm.core import BadValueError, APartName, Future, Put, Request
+from malcolm.modules import builtin
+from ..infos import DatasetProducedInfo
+from ..hooks import UInfos
 from ..hooks import ConfigureHook, PostRunArmedHook, \
     SeekHook, RunHook, ResumeHook, ACompletedSteps, AContext, ValidateHook, \
     UParameterTweakInfos, PostRunReadyHook, AbortHook, PreConfigureHook, \
@@ -18,18 +18,23 @@ if TYPE_CHECKING:
 with Anno("The detectors that should be active and their exposures"):
     ADetectorTable = DetectorTable
 
+# Pull re-used annotypes into our namespace in case we are subclassed
+APartName = APartName
+AMri = builtin.parts.AMri
+AInitialVisibility = builtin.parts.AInitialVisibility
 
 ss = RunnableStates
 
 
-class DetectorChildPart(ChildPart):
+class DetectorChildPart(builtin.parts.ChildPart):
     """Part controlling a child detector Block that exposes a configure/run
     interface with fileDir and fileTemplate"""
 
     def __init__(self,
                  name,  # type: APartName
                  mri,  # type: AMri
-                 initial_visibility=False,  # type: AInitialVisibility
+                 initial_visibility=False,
+                 # type: AInitialVisibility
                  ):
         # type: (...) -> None
         super(DetectorChildPart, self).__init__(name, mri, initial_visibility)
@@ -176,7 +181,8 @@ class DetectorChildPart(ChildPart):
             "Detector %s doesn't have a dataset table, did you add a " \
             "DatasetTablePart to it?" % self.mri
         datasets_table = child.datasets.value
-        info_list = [DatasetProducedInfo(*row) for row in datasets_table.rows()]
+        info_list = [DatasetProducedInfo(*row) for
+                     row in datasets_table.rows()]
         return info_list
 
     @add_call_types

--- a/malcolm/modules/scanning/parts/detectorchildpart.py
+++ b/malcolm/modules/scanning/parts/detectorchildpart.py
@@ -3,13 +3,12 @@ from annotypes import add_call_types, Anno, Any, TYPE_CHECKING, stringify_error
 from malcolm.core import BadValueError, APartName, Future, Put, Request
 from malcolm.modules import builtin
 from ..infos import DatasetProducedInfo
-from ..hooks import UInfos
 from ..hooks import ConfigureHook, PostRunArmedHook, \
     SeekHook, RunHook, ResumeHook, ACompletedSteps, AContext, ValidateHook, \
     UParameterTweakInfos, PostRunReadyHook, AbortHook, PreConfigureHook, \
-    AGenerator, AAxesToMove
+    AGenerator, AAxesToMove, UInfos, AFileDir, AFileTemplate
 from ..infos import ParameterTweakInfo, RunProgressInfo
-from ..util import RunnableStates, AFileDir, AFileTemplate, DetectorTable
+from ..util import RunnableStates, DetectorTable
 
 if TYPE_CHECKING:
     from typing import Dict, Tuple

--- a/malcolm/modules/scanning/parts/minturnaroundpart.py
+++ b/malcolm/modules/scanning/parts/minturnaroundpart.py
@@ -18,8 +18,6 @@ class MinTurnaroundPart(Part):
             tags=[Widget.TEXTINPUT.tag(), config_tag()],
             display=Display(precision=6, units="s")
         ).create_attribute_model(value)
-        # Hooks
-        self.register_hooked(ReportStatusHook, self.report_status)
 
     @add_call_types
     def report_status(self):
@@ -30,3 +28,5 @@ class MinTurnaroundPart(Part):
         # type: (PartRegistrar) -> None
         registrar.add_attribute_model(
             "minTurnaround", self.attr, self.attr.set_value)
+        # Hooks
+        registrar.hook(ReportStatusHook, self.report_status)

--- a/malcolm/modules/scanning/parts/simultaneousaxespart.py
+++ b/malcolm/modules/scanning/parts/simultaneousaxespart.py
@@ -18,8 +18,6 @@ class SimultaneousAxesPart(Part):
             "Set of axes that can be specified in axesToMove at configure",
             tags=[Widget.TEXTINPUT.tag(), config_tag()]
         ).create_attribute_model(value)
-        # Hooks
-        self.register_hooked(ValidateHook, self.validate)
 
     # This will be serialized, so maintain camelCase for axesToMove
     # noinspection PyPep8Naming
@@ -34,3 +32,5 @@ class SimultaneousAxesPart(Part):
         # type: (PartRegistrar) -> None
         registrar.add_attribute_model(
             "simultaneousAxes", self.attr, self.attr.set_value)
+        # Hooks
+        registrar.hook(ValidateHook, self.validate)

--- a/malcolm/modules/scanning/util.py
+++ b/malcolm/modules/scanning/util.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from malcolm.core import VMeta, NTUnion, Table, NumberMeta, Widget, \
     Display, AttributeModel
-from malcolm.modules.builtin.util import ManagerStates
+from malcolm.modules import builtin
 
 with Anno("Generator instance providing specification for scan"):
     AGenerator = CompoundGenerator
@@ -175,7 +175,7 @@ class DetectorTable(Table):
         self.framesPerStep = AFramesPerStep(framesPerStep)
 
 
-class RunnableStates(ManagerStates):
+class RunnableStates(builtin.util.ManagerStates):
     """This state set covers controllers and parts that can be configured and
     then run, and have the ability to pause and rewind"""
 

--- a/malcolm/modules/scanning/util.py
+++ b/malcolm/modules/scanning/util.py
@@ -1,3 +1,10 @@
+""" scanning.utils provides shared utility functions and classes.
+For consistency and to avoid circular dependencies, the following
+rules are applied:
+- All types required to initialize hook classes are in the hooks namespace
+- All types required to initialize info classes are in the infos namespace
+- util depends on hooks and infos (not vice versa)"""
+
 from annotypes import Anno, Array, Union, Sequence, Any, Serializable
 from scanpointgenerator import CompoundGenerator
 import numpy as np
@@ -8,13 +15,6 @@ from malcolm.modules import builtin
 from .infos import DatasetType
 
 from .hooks import AGenerator, AAxesToMove, UAxesToMove
-
-""" scanning.utils provides shared utility functions and classes.
-For consistency and to avoid circular dependencies, the following
-rules are applied:
-- All types required to initialize hook classes are in the hooks namespace
-- All types required to initialize info classes are in the infos namespace
-- util depends on hooks and infos (not vice versa)"""
 
 
 def exposure_attribute(min_exposure):

--- a/malcolm/modules/scanning/util.py
+++ b/malcolm/modules/scanning/util.py
@@ -1,27 +1,13 @@
 from annotypes import Anno, Array, Union, Sequence, Any, Serializable
-from enum import Enum
 from scanpointgenerator import CompoundGenerator
 import numpy as np
 
 from malcolm.core import VMeta, NTUnion, Table, NumberMeta, Widget, \
     Display, AttributeModel
 from malcolm.modules import builtin
+from .infos import DatasetType
 
-with Anno("Generator instance providing specification for scan"):
-    AGenerator = CompoundGenerator
-with Anno("List of axes in inner dimension of generator that should be moved"):
-    AAxesToMove = Array[str]
-UAxesToMove = Union[AAxesToMove, Sequence[str]]
-with Anno("Directory to write data to"):
-    AFileDir = str
-with Anno("Argument for fileTemplate, normally filename without extension"):
-    AFormatName = str
-with Anno("""Printf style template to generate filename relative to fileDir.
-Arguments are:
-  1) %s: the value of formatName"""):
-    AFileTemplate = str
-with Anno("The demand exposure time of this scan, 0 for the maximum possible"):
-    AExposure = float
+from .hooks import AGenerator, AAxesToMove, UAxesToMove
 
 
 def exposure_attribute(min_exposure):
@@ -88,22 +74,6 @@ class PointGeneratorMeta(VMeta):
         else:
             raise TypeError(
                 "Value %s must be a Generator object or dictionary" % value)
-
-
-class DatasetType(Enum):
-    """NeXus type of a produced dataset"""
-    #: Detector data, like the 2D data from an imaging detector
-    PRIMARY = "primary"
-    #: Calculated from detector data, like the sum of each frame
-    SECONDARY = "secondary"
-    #: Data that only makes sense when considered with detector data, like a
-    #: measure of beam current with an ion chamber
-    MONITOR = "monitor"
-    #: The demand positions of an axis as specified by the generator
-    POSITION_SET = "position_set"
-    #: The readback positions of an axis that moves during the sacn
-    POSITION_VALUE = "position_value"
-
 
 with Anno("Dataset names"):
     ADatasetNames = Array[str]

--- a/malcolm/modules/scanning/util.py
+++ b/malcolm/modules/scanning/util.py
@@ -9,6 +9,13 @@ from .infos import DatasetType
 
 from .hooks import AGenerator, AAxesToMove, UAxesToMove
 
+""" scanning.utils provides shared utility functions and classes.
+For consistency and to avoid circular dependencies, the following
+rules are applied:
+- All types required to initialize hook classes are in the hooks namespace
+- All types required to initialize info classes are in the infos namespace
+- util depends on hooks and infos (not vice versa)"""
+
 
 def exposure_attribute(min_exposure):
     # type: (float) -> AttributeModel

--- a/malcolm/modules/web/hooks.py
+++ b/malcolm/modules/web/hooks.py
@@ -1,12 +1,15 @@
 from annotypes import Anno, Array, Sequence, Union
 
 from malcolm.core import Hook
-from malcolm.modules.builtin.hooks import APart
+from malcolm.modules import builtin
 from .infos import HandlerInfo
 
 with Anno("Any handlers and regexps that should form part of tornado App"):
     AHandlerInfos = Array[HandlerInfo]
 UHandlerInfos = Union[AHandlerInfos, Sequence[HandlerInfo], HandlerInfo, None]
+
+# Pull re-used annotypes into our namespace in case we are subclassed
+APart = builtin.hooks.APart
 
 
 class ReportHandlersHook(Hook):

--- a/malcolm/modules/web/parts/guiserverpart.py
+++ b/malcolm/modules/web/parts/guiserverpart.py
@@ -3,7 +3,7 @@ import os
 from annotypes import Anno, add_call_types
 from tornado.web import StaticFileHandler, RedirectHandler
 
-from malcolm.core import Part, APartName
+from malcolm.core import Part, APartName, PartRegistrar
 from ..hooks import ReportHandlersHook, UHandlerInfos
 from ..infos import HandlerInfo
 
@@ -30,8 +30,12 @@ class GuiServerPart(Part):
         # type: (APartName, APath) -> None
         super(GuiServerPart, self).__init__(name)
         self.path = path
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(GuiServerPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(ReportHandlersHook, self.report_handlers)
+        registrar.hook(ReportHandlersHook, self.report_handlers)
 
     @add_call_types
     def report_handlers(self):

--- a/malcolm/modules/web/parts/restfulserverpart.py
+++ b/malcolm/modules/web/parts/restfulserverpart.py
@@ -61,8 +61,12 @@ class RestfulServerPart(Part):
     def __init__(self, name="rest"):
         # type: (AName) -> None
         super(RestfulServerPart, self).__init__(name)
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(RestfulServerPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(ReportHandlersHook, self.report_handlers)
+        registrar.hook(ReportHandlersHook, self.report_handlers)
 
     @add_call_types
     def report_handlers(self):

--- a/malcolm/modules/web/parts/websocketserverpart.py
+++ b/malcolm/modules/web/parts/websocketserverpart.py
@@ -163,8 +163,12 @@ class WebsocketServerPart(Part):
         # type: (AName, ASubnetValidation) -> None
         super(WebsocketServerPart, self).__init__(name)
         self.subnet_validation = subnet_validation
+
+    def setup(self, registrar):
+        # type: (PartRegistrar) -> None
+        super(WebsocketServerPart, self).setup(registrar)
         # Hooks
-        self.register_hooked(ReportHandlersHook, self.report_handlers)
+        registrar.hook(ReportHandlersHook, self.report_handlers)
 
     @add_call_types
     def report_handlers(self):

--- a/malcolm/modules/xmap/parts/xmapdriverpart.py
+++ b/malcolm/modules/xmap/parts/xmapdriverpart.py
@@ -19,7 +19,7 @@ class XmapDriverPart(ADCore.parts.DetectorDriverPart):
                   steps_to_do,  # type: scanning.hooks.AStepsToDo
                   part_info,  # type: scanning.hooks.APartInfo
                   generator,  # type: scanning.hooks.AGenerator
-                  fileDir,  # type: scanning.util.AFileDir
+                  fileDir,  # type: scanning.hooks.AFileDir
                   **kwargs  # type: **Any
                   ):
         # type: (...) -> None

--- a/malcolm/testutil.py
+++ b/malcolm/testutil.py
@@ -5,7 +5,7 @@ from mock import MagicMock as Mock, patch
 
 from malcolm.core import Hook, Part, Controller, Process, ProcessPublishHook, \
     APublished, ProcessStartHook, UnpublishedInfo
-from malcolm.modules.builtin.controllers import ManagerController
+from malcolm.modules import builtin
 
 if TYPE_CHECKING:
     from typing import List, Any, Type, Callable, Optional
@@ -32,7 +32,8 @@ class ChildTestCase(unittest.TestCase):
         controllers = child_block(**params)
         for controller in controllers:
             process.add_controller(controller)
-            if not isinstance(controller, ManagerController):
+            if not isinstance(controller,
+                              builtin.controllers.ManagerController):
                 # We've already setup the CAParts and added to the block, so we
                 # can safely delete them so they don't try to connect
                 controller.parts = {}

--- a/tests/test_modules/test_scanning/test_datasettablepart.py
+++ b/tests/test_modules/test_scanning/test_datasettablepart.py
@@ -4,11 +4,15 @@ from malcolm.modules.scanning.parts import DatasetTablePart
 from malcolm.modules.scanning.infos import DatasetProducedInfo
 from malcolm.modules.scanning.util import DatasetType
 
+from mock import MagicMock
+
 
 class TestDatasetReportingPart(unittest.TestCase):
 
     def setUp(self):
+        self.r = MagicMock()
         self.o = DatasetTablePart(name="n")
+        self.o.setup(self.r)
 
     def test_init(self):
         assert list(self.o.datasets.meta.elements) == (

--- a/tests/test_modules/test_scanning/test_detectorchildpart.py
+++ b/tests/test_modules/test_scanning/test_detectorchildpart.py
@@ -10,11 +10,11 @@ from malcolm.core import Part, Process, Context, APartName, PartRegistrar, \
     NumberMeta, BadValueError
 from malcolm.modules.builtin.hooks import AContext
 from malcolm.modules.builtin.util import set_tags
-from malcolm.modules.scanning.hooks import RunHook,ConfigureHook
 from malcolm.modules.scanning.parts import DetectorChildPart, DatasetTablePart
 from malcolm.modules.scanning.controllers import RunnableController
-from malcolm.modules.scanning.util import AFileDir, AFormatName, AFileTemplate, \
-    DetectorTable
+from malcolm.modules.scanning.hooks import AFileDir, AFormatName, \
+    AFileTemplate, RunHook, ConfigureHook
+from malcolm.modules.scanning.util import DetectorTable
 
 with Anno("How long to wait"):
     AWait = float

--- a/tests/test_modules/test_scanning/test_runnablecontroller.py
+++ b/tests/test_modules/test_scanning/test_runnablecontroller.py
@@ -6,7 +6,7 @@ from annotypes import add_call_types
 
 from malcolm.modules.demo.parts.motionchildpart import AExceptionStep
 from malcolm.modules.scanning.hooks import ACompletedSteps, AContext, \
-    AStepsToDo, ValidateHook, UInfos
+    AStepsToDo, ValidateHook, UInfos, AAxesToMove, AGenerator
 from malcolm.core import Process, Context, AlarmStatus, \
     AlarmSeverity, AbortedError
 from malcolm.modules.demo.parts import MotionChildPart
@@ -15,8 +15,7 @@ from malcolm.compat import OrderedDict
 from malcolm.modules.scanning.controllers import \
     RunnableController
 from malcolm.modules.scanning.infos import ParameterTweakInfo
-from malcolm.modules.scanning.util import RunnableStates, AGenerator, \
-    AAxesToMove
+from malcolm.modules.scanning.util import RunnableStates
 
 
 class MisbehavingPauseException(Exception):


### PR DESCRIPTION
Tidy up code:

- standardize imports
- pull init parameter types into local namespace for access by subclasses
- move hook registration to setup()
- declare attributes and methods at the class level when __init__() not required
