### PR TITLE
Velocity mode changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ install:
   - ls -al ${VIRTUAL_ENV}/bin
   - pip install "setuptools>=36"
   - pip install setuptools_dso epicscorelibs
+  # attempt to clear issue with numpy requiring cache clearing
+  - pip uninstall --yes numpy
+  - pip uninstall --yes numpy
   - pip install -r requirements/test.txt
   - pip install codecov
   - ls -al ${VIRTUAL_ENV}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages

--- a/malcolm/core/errors.py
+++ b/malcolm/core/errors.py
@@ -38,6 +38,11 @@ class FieldError(MalcolmException):
     pass
 
 
+class IncompatibleError(MalcolmException):
+    """Incompatibility between components of this scan"""
+    pass
+
+
 class NotWriteableError(MalcolmException):
     """The field is not currently writeable, so cannot Put or Post to it"""
 

--- a/malcolm/modules/pmac/blocks/pmac_trajectory_block.yaml
+++ b/malcolm/modules/pmac/blocks/pmac_trajectory_block.yaml
@@ -208,4 +208,8 @@
     pv: $(pv_prefix):Z:Positions
     config: False
 
-
+- ca.parts.CADoublePart:
+    name: trajectoryProgVersion
+    description: the version number of the pmac's trajectory program
+    rbv: $(pv_prefix):ProgramVersion_RBV
+    config: False

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -504,7 +504,7 @@ class PmacChildPart(builtin.parts.ChildPart):
             # Add lower bound
             user_program = self.get_user_program(PointType.START_OF_ROW)
             self.add_profile_point(
-                run_up_time, CURRENT_TO_NEXT, user_program, start_index,
+                run_up_time, PREV_TO_CURRENT, user_program, start_index,
                 axis_points)
 
         for i in range(start_index, self.steps_up_to):
@@ -584,6 +584,6 @@ class PmacChildPart(builtin.parts.ChildPart):
             time_arrays, velocity_arrays, start_positions, completed_steps)
 
         # Change the last point to be a live frame
-        self.profile["velocityMode"][-1] = CURRENT_TO_NEXT
+        self.profile["velocityMode"][-1] = PREV_TO_CURRENT
         user_program = self.get_user_program(PointType.START_OF_ROW)
         self.profile["userPrograms"][-1] = user_program

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -6,11 +6,11 @@ from enum import Enum
 
 import numpy as np
 from annotypes import add_call_types, TYPE_CHECKING
+from scanpointgenerator import CompoundGenerator
+
 from malcolm.core import Future, Block, PartRegistrar, Put, Request
 from malcolm.modules import builtin, scanning
 from malcolm.modules.pmac.util import get_motion_trigger
-from scanpointgenerator import CompoundGenerator
-
 from ..infos import MotorInfo
 from ..util import cs_axis_mapping, points_joined, point_velocities, MIN_TIME, \
     profile_between_points, cs_port_with_motors_in, get_motion_axes
@@ -20,9 +20,6 @@ if TYPE_CHECKING:
 
 # Number of seconds that a trajectory tick is
 TICK_S = 0.000001
-
-# Interval for interpolating velocity curves
-INTERPOLATE_INTERVAL = 0.02
 
 # Longest move time we can request
 MAX_MOVE_TIME = 4.0

--- a/malcolm/modules/pmac/parts/pmactrajectorypart.py
+++ b/malcolm/modules/pmac/parts/pmactrajectorypart.py
@@ -1,10 +1,13 @@
 import numpy as np
 from annotypes import add_call_types, Anno, Array
 
-from malcolm.core import PartRegistrar, BooleanMeta, config_tag, Widget, \
-    NumberMeta
+from malcolm.core import PartRegistrar, Widget, \
+    NumberMeta, errors
 from malcolm.modules import builtin
 from ..util import CS_AXIS_NAMES
+
+# expected trajectory program number
+TRAJECTORY_PROGRAM_NUM = 2
 
 # The maximum number of points in a single trajectory scan
 MAX_NUM_POINTS = 4000000
@@ -90,6 +93,19 @@ class PmacTrajectoryPart(builtin.parts.ChildPart):
                       ):
         # type: (...) -> None
         child = context.block_view(self.mri)
+
+        # make sure a matching trajectory program is installed on the pmac
+        if child.trajectoryProgVersion.value != TRAJECTORY_PROGRAM_NUM:
+            raise (
+                errors.IncompatibleError(
+                    "pmac trajectory program {} detected. "
+                    "Malcolm requires {}".format(
+                        child.trajectoryProgVersion.value,
+                        TRAJECTORY_PROGRAM_NUM
+                    )
+                )
+            )
+
         # The axes taking part in the scan
         use_axes = []
         for axis in CS_AXIS_NAMES:

--- a/malcolm/modules/pmac/util.py
+++ b/malcolm/modules/pmac/util.py
@@ -124,15 +124,15 @@ def point_velocities(axis_mapping, point, entry=True):
         vp = dp / point.duration
         if entry:
             # Halfway point is vlp, so calculate dlp
-            dhalf = point.positions[axis_name] - point.lower[axis_name]
+            d_half = point.positions[axis_name] - point.lower[axis_name]
         else:
             # Halfway point is vpu, so calculate dpu
-            dhalf = point.upper[axis_name] - point.positions[axis_name]
+            d_half = point.upper[axis_name] - point.positions[axis_name]
         # Extrapolate to get our entry or exit velocity
         # (vl + vp) / 2 = vlp
         # so vl = 2 * vlp - vp
         # where vlp = dlp / (t/2)
-        velocity = 4 * dhalf / point.duration - vp
+        velocity = 4 * d_half / point.duration - vp
         assert abs(velocity) < motor_info.max_velocity, \
             "Velocity %s invalid for %r with max_velocity %s" % (
                 velocity, axis_name, motor_info.max_velocity)
@@ -141,7 +141,7 @@ def point_velocities(axis_mapping, point, entry=True):
 
 
 def profile_between_points(axis_mapping, point, next_point, min_time=MIN_TIME):
-    # type: (Dict[str, MotorInfo], Point, Point) -> Tuple[Profiles, Profiles]
+    # type: (Dict[str, MotorInfo], Point, Point, float) -> Tuple[Profiles, Profiles]
     """Make consistent time and velocity arrays for each axis
 
     Try to create velocity profiles for all axes that all arrive at

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def get_version():
                            .format(VERSION_FILE))
 
 install_requires = [
-    'enum34==1.1.6', "numpy==1.13.1", "annotypes==0.17", "cothread==2.14"]
+    'enum34==1.1.6', "numpy>=1.13.1", "annotypes>=0.17", "cothread>=2.14"]
 
 
 def add_multiversion_require(module):

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -119,7 +119,7 @@ class TestPMACChildPart(ChildTestCase):
                            500000, 500000, 500000, 500000, 500000, 100000]),
                       userPrograms=pytest.approx(user_programs),
                       velocityMode=pytest.approx(
-                          [2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 0, 0, 0,
+                          [1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0,
                            0, 0, 1, 3])
                       )
         ]
@@ -152,7 +152,7 @@ class TestPMACChildPart(ChildTestCase):
                           [1, 4, 1, 4, 1, 4, 2, 8, 8, 8, 8, 1, 4, 1, 4, 1, 4,
                            2, 8]),
                       velocityMode=pytest.approx(
-                          [2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 1,
+                          [1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1,
                            3])
                       )
         ]
@@ -199,7 +199,7 @@ class TestPMACChildPart(ChildTestCase):
                       userPrograms=pytest.approx([
                           1, 4, 1, 4, 1, 4, 1, 4, 1, 4, 1, 4, 2, 8]),
                       velocityMode=pytest.approx([
-                          2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
+                          1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
             ]
         assert self.o.completed_steps_lookup == [
             0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6]
@@ -270,7 +270,7 @@ class TestPMACChildPart(ChildTestCase):
                     100000, 500000, 500000, 500000, 500000, 500000, 500000,
                     100000]),
                 userPrograms=pytest.approx([1, 4, 1, 4, 1, 4, 2, 8]),
-                velocityMode=pytest.approx([2, 0, 0, 0, 0, 0, 1, 3])),
+                velocityMode=pytest.approx([1, 0, 0, 0, 0, 0, 1, 3])),
             ]
 
     def test_long_steps_lookup(self):
@@ -290,7 +290,7 @@ class TestPMACChildPart(ChildTestCase):
             userPrograms=pytest.approx([
                 1, 0, 4, 0, 1, 0, 4, 0, 1, 0, 4, 0, 2, 8]),
             velocityMode=pytest.approx([
-                2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
         assert self.o.completed_steps_lookup == (
             [3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6])
 
@@ -313,7 +313,7 @@ class TestPMACChildPart(ChildTestCase):
             userPrograms=pytest.approx([
                 1, 0, 4, 0, 1, 0, 4, 0, 1]),
             velocityMode=pytest.approx([
-                2, 0, 0, 0, 0, 0, 0, 0, 0]))
+                1, 0, 0, 0, 0, 0, 0, 0, 0]))
         # The completed steps works on complete (not split) steps, so we expect
         # the last value to be the end of step 6, even though it doesn't
         # actually appear in the velocity arrays

--- a/tests/test_modules/test_pmac/test_pmactrajectorypart.py
+++ b/tests/test_modules/test_pmac/test_pmactrajectorypart.py
@@ -25,6 +25,7 @@ class TestPMACTrajectoryPart(ChildTestCase):
         self.process.add_controller(c)
         self.process.start()
         self.b = c.block_view()
+        self.set_attributes(self.child, trajectoryProgVersion=2)
 
     def tearDown(self):
         self.process.stop(timeout=1)


### PR DESCRIPTION
Tom,

I'm making a PR but this is a breaking change since Malcolm now requires trajectory prog v2 (which is checked in but not released).

Changes:

- fix velocity mode calculation for PREV_NEXT
- change turnaround points generation to use acceleration change points only and alway PREV_NEXT velocity mode
- error if the trajectory program is not v2
