### PR TITLE
Sparse trajectories only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,29 @@
-dist: xenial # required for python 3.7
+dist: xenial # required for python 3.7- builtin.parameters.string:
+    name: mri
+    description: Malcolm resource id of the Block
+
+- builtin.parameters.string:
+    name: pv_prefix
+    description: The root PV for the trajectory scan template
+
+- builtin.defines.docstring:
+    value: Hardware block corresponding to PVs used for trajectory scan
+
+- builtin.controllers.StatefulController:
+    mri: $(mri)
+    description: $(docstring)
+
+- ca.parts.CAChoicePart:
+    name: cs
+    description: Co-ordinate system name that should be trajectory scanned
+    pv: $(pv_prefix):ProfileCsName
+    rbv_suffix: _RBV
+
+- ca.parts.CAStringPart:
+    name: pmac
+    description: Port name of parent PMAC object
+    rbv: $(pv_prefix):ParentPort
+    sink_port: motor
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,4 @@
-dist: xenial # required for python 3.7- builtin.parameters.string:
-    name: mri
-    description: Malcolm resource id of the Block
-
-- builtin.parameters.string:
-    name: pv_prefix
-    description: The root PV for the trajectory scan template
-
-- builtin.defines.docstring:
-    value: Hardware block corresponding to PVs used for trajectory scan
-
-- builtin.controllers.StatefulController:
-    mri: $(mri)
-    description: $(docstring)
-
-- ca.parts.CAChoicePart:
-    name: cs
-    description: Co-ordinate system name that should be trajectory scanned
-    pv: $(pv_prefix):ProfileCsName
-    rbv_suffix: _RBV
-
-- ca.parts.CAStringPart:
-    name: pmac
-    description: Port name of parent PMAC object
-    rbv: $(pv_prefix):ParentPort
-    sink_port: motor
+dist: xenial # required for python 3.7
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ install:
   - ifconfig
   - ls -al ${VIRTUAL_ENV}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages
   - ls -al ${VIRTUAL_ENV}/bin
-  - pip install "setuptools>=36"
-  - pip install setuptools_dso epicscorelibs
+  # attempt to clear issue with numpy requiring cache clearing
+  - pip uninstall --yes numpy
+  - pip uninstall --yes numpy
   - pip install -r requirements/test.txt
   - pip install codecov
   - ls -al ${VIRTUAL_ENV}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages

--- a/docs/tutorials/panda.rst
+++ b/docs/tutorials/panda.rst
@@ -44,15 +44,15 @@ tables to the correct values::
         mri: BLxxI-ML-PANDA-01
         initial_visibility: True
 
-    - ADPandABlocks.blocks.panda_pcomp_block:
-        mri: $(mri_prefix):PCOMP
+    - ADPandABlocks.blocks.panda_seq_trigger_block:
+        mri: $(mri_prefix):TRIG
         panda: BLxxI-ML-PANDA-01
         pmac: BLxxI-ML-BRICK-01
 
     # Make this initially invisible so it doesn't disturb existing scans
-    - ADPandABlocks.parts.PandAPcompPart:
-        name: PCOMP
-        mri: $(mri_prefix):PCOMP
+    - ADPandABlocks.parts.PandASeqTriggerPart:
+        name: TRIG
+        mri: $(mri_prefix):TRIG
         initial_visibility: False
 
 The `DetectorChildPart` definition for the PandA is unchanged, the PCOMP Block

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -501,7 +501,7 @@ class PmacChildPart(builtin.parts.ChildPart):
         else:
             # otherwise skip this point if is is linear to previous point
             do_skip = next_point and points_are_joined and \
-                      self.is_equidistant(point, next_point)
+                      self.is_same_velocity(point, next_point)
 
         if do_skip:
             self.time_since_last_pvt += point.duration
@@ -623,15 +623,17 @@ class PmacChildPart(builtin.parts.ChildPart):
         user_program = self.get_user_program(PointType.START_OF_ROW)
         self.profile["userPrograms"][-1] = user_program
 
-    def is_equidistant(self, p1, p2):
+    def is_same_velocity(self, p1, p2):
         result = False
-        # handle p1 = None, i.e. no previous point
         if p2.duration == p2.duration:
             result = True
-            for axis_name, motor_info in self.axis_mapping.items():
+            for axis_name, _ in self.axis_mapping.items():
                 if not np.isclose(
                     p1.lower[axis_name] - p1.positions[axis_name],
                     p2.lower[axis_name] - p2.positions[axis_name]
+                ) or not np.isclose(
+                    p1.positions[axis_name] - p1.upper[axis_name],
+                    p2.positions[axis_name] - p2.upper[axis_name]
                 ):
                     result = False
                     break

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -471,77 +471,65 @@ class PmacChildPart(builtin.parts.ChildPart):
             cs_axis = self.axis_mapping[k].cs_axis.lower()
             self.profile[cs_axis].append(v)
 
-    def add_generator_point_pair(self, point, num, next_point, is_final_point,
-                                 points_are_joined):
+    def add_generator_point_pair(self, point, point_num, points_are_joined):
         # Add position
         user_program = self.get_user_program(PointType.MID_POINT)
         self.add_profile_point(
-            point.duration / 2.0, PREV_TO_NEXT, user_program, num,
+            point.duration / 2.0, PREV_TO_NEXT, user_program, point_num,
             {name: point.positions[name] for name in self.axis_mapping})
 
-        if is_final_point:
-            # No more frames, dead frame to finish
-            user_program = self.get_user_program(PointType.END_OF_ROW)
-            self.add_profile_point(
-                point.duration / 2.0, PREV_TO_CURRENT, user_program, num + 1,
-                {name: point.upper[name] for name in self.axis_mapping})
+        # insert the lower bound of the next frame
+        if points_are_joined:
+            user_program = self.get_user_program(PointType.POINT_JOIN)
+            velocity_point = PREV_TO_NEXT
         else:
-            # insert the lower bound of the next frame if required
-            if points_are_joined:
-                user_program = self.get_user_program(PointType.POINT_JOIN)
-                velocity_point = PREV_TO_NEXT
-            else:
-                user_program = self.get_user_program(PointType.END_OF_ROW)
-                velocity_point = PREV_TO_CURRENT
-
-            self.add_profile_point(
-                point.duration / 2.0, velocity_point, user_program, num + 1,
-                {name: point.upper[name] for name in self.axis_mapping})
-
-            if not points_are_joined:
-                self.insert_gap(point, next_point, num + 1)
-
-    def add_sparse_point(
-            self, point, num, next_point, is_final_point, points_are_joined
-    ):
-        pvt_point = None
-        self.time_since_last_pvt += point.duration
-        if is_final_point:
-            # No more frames, dead frame to finish
             user_program = self.get_user_program(PointType.END_OF_ROW)
+            velocity_point = PREV_TO_CURRENT
+
+        self.add_profile_point(
+            point.duration / 2.0, velocity_point, user_program, point_num + 1,
+            {name: point.upper[name] for name in self.axis_mapping})
+
+    def add_sparse_point(self, point, point_num, next_point, points_are_joined):
+        # todo when branch velocity-mode-changes is merged we will
+        #  need to set velocity mode CURRENT_TO_NEXT on the *previous*
+        #  point whenever we skip a point
+        if self.time_since_last_pvt > 0 and not points_are_joined:
+            # assume we can skip if we are at the end of a row and we
+            # just skipped the most recent point (i.e. time_since_last_pvt > 0)
+            do_skip = True
+        else:
+            # otherwise skip this point if is is linear to previous point
+            do_skip = next_point and points_are_joined and \
+                      self.is_equidistant(point, next_point)
+
+        if do_skip:
+            self.time_since_last_pvt += point.duration
+        else:
+            # not skipping - add this mid point
+            user_program = self.get_user_program(PointType.MID_POINT)
             self.add_profile_point(
-                self.time_since_last_pvt,
-                PREV_TO_CURRENT, user_program, num + 1,
-                {name: point.upper[name] for name in self.axis_mapping}
-            )
+                self.time_since_last_pvt + point.duration / 2.0,
+                PREV_TO_NEXT, user_program, point_num,
+                {name: point.positions[name] for name in self.axis_mapping})
+            self.time_since_last_pvt = point.duration / 2.0
+
+        # insert the lower bound of the next frame
+        if points_are_joined:
+            user_program = self.get_user_program(PointType.POINT_JOIN)
+            velocity_point = PREV_TO_NEXT
+        else:
+            user_program = self.get_user_program(PointType.END_OF_ROW)
+            velocity_point = PREV_TO_CURRENT
+
+        # only add the lower bound if we did not skip this point OR if we are
+        # at the end of a row where we always require a final point
+        if not do_skip or not points_are_joined:
+            self.add_profile_point(
+                self.time_since_last_pvt, velocity_point,
+                user_program, point_num + 1,
+                {name: point.upper[name] for name in self.axis_mapping})
             self.time_since_last_pvt = 0
-        else:
-            if points_are_joined:
-                # skip this point if is is linear with respect to previous
-                # todo when branch velocity-mode-changes is merged we will
-                #  need to set velocity mode CURRENT_TO_NEXT on the previous
-                #  point whenever we drop a point
-                if self.is_equidistant(point, next_point):
-                    # skip this point
-                    pass
-                else:
-                    user_program = self.get_user_program(PointType.POINT_JOIN)
-                    self.add_profile_point(
-                        self.time_since_last_pvt, PREV_TO_NEXT,
-                        user_program, num + 1,
-                        {name: point.upper[name] for name in self.axis_mapping})
-                    self.time_since_last_pvt = 0
-            else:
-                user_program = self.get_user_program(PointType.END_OF_ROW)
-                self.add_profile_point(
-                    self.time_since_last_pvt, PREV_TO_CURRENT,
-                    user_program, num + 1,
-                    {name: point.upper[name] for name in self.axis_mapping})
-                self.time_since_last_pvt = 0
-
-                self.insert_gap(point, next_point, num + 1)
-
-        return pvt_point
 
     def calculate_generator_profile(self, start_index, do_run_up=False):
         # If we are doing the first build, do_run_up will be passed to flag
@@ -572,24 +560,22 @@ class PmacChildPart(builtin.parts.ChildPart):
             if i + 1 < self.steps_up_to:
                 # Check if we need to insert the lower bound of next_point
                 next_point = self.generator.get_point(i + 1)
+
                 points_are_joined = points_joined(
                     self.axis_mapping, point, next_point
                 )
-                is_final_point = False
             else:
-                is_final_point = True
                 points_are_joined = False
                 next_point = None
 
             if self.output_triggers != scanning.infos.MotionTrigger.ROW_GATE:
-                self.add_generator_point_pair(
-                    point, i, next_point, is_final_point, points_are_joined
-                )
+                self.add_generator_point_pair(point, i, points_are_joined)
             else:
-                self.add_sparse_point(
-                    point, i, next_point, is_final_point, points_are_joined
-                )
-            prev_point = point
+                self.add_sparse_point(point, i, next_point, points_are_joined)
+
+            # add in the turnaround between non-contiguous points
+            if not points_are_joined and next_point is not None:
+                self.insert_gap(point, next_point, i + 1)
 
             # Check if we have exceeded the points number and need to write
             # Strictly less than so we always add one more point to the time

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -504,13 +504,15 @@ class PmacChildPart(builtin.parts.ChildPart):
                 point.duration / 2.0, PREV_TO_CURRENT, user_program, num + 1,
                 {name: point.upper[name] for name in self.axis_mapping})
 
-    def add_sparse_point_pair(
+    def add_sparse_point(
             self, point, num, next_point, is_final_point, points_are_joined):
         pvt_point = None
         if not is_final_point:
+            self.time_since_last_pvt += point.duration
             if points_are_joined:
-                # skip this point TODO more logic required for non linear
-                self.time_since_last_pvt += point.interval
+                # skip this point
+                # TODO more logic required for non linear generators
+                pass
             else:
                 user_program = self.get_user_program(PointType.END_OF_ROW)
                 velocity_point = PREV_TO_CURRENT
@@ -518,6 +520,7 @@ class PmacChildPart(builtin.parts.ChildPart):
                     self.time_since_last_pvt, velocity_point,
                     user_program, num + 1,
                     {name: point.upper[name] for name in self.axis_mapping})
+                self.time_since_last_pvt = 0
 
             if not points_are_joined:
                 self.insert_gap(point, next_point, num + 1)
@@ -576,12 +579,9 @@ class PmacChildPart(builtin.parts.ChildPart):
                     point, i, next_point, is_final_point, points_are_joined
                 )
             else:
-                self.add_generator_point_pair(
+                self.add_sparse_point(
                     point, i, next_point, is_final_point, points_are_joined
                 )
-                # self.add_sparse_point_pair(
-                #     point, i, next_point, is_final_point, points_are_joined
-                # )
 
             # Check if we have exceeded the points number and need to write
             # Strictly less than so we always add one more point to the time

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -85,6 +85,9 @@ class PmacChildPart(builtin.parts.ChildPart):
         # Profile points that haven't been sent yet
         # {timeArray/velocityMode/userPrograms/a/b/c/u/v/w/x/y/z: [elements]}
         self.profile = {}
+        # accumulated intervals since the last PVT point used by sparse
+        # trajectory logic
+        self.time_since_last_pvt = 0
         # Stored generator for positions
         self.generator = None  # type: CompoundGenerator
 
@@ -164,7 +167,7 @@ class PmacChildPart(builtin.parts.ChildPart):
     def move_to_start(self, child, cs_port, completed_steps):
         # type: (Block, str, int) -> Future
         # Work out what method to call
-        match = re.search("\d+$", cs_port)
+        match = re.search(r"\d+$", cs_port)
         assert match, "Cannot extract CS number from CS port '%s'" % cs_port
         move_async = child["moveCS%s_async" % match.group()]
         # Set all the axes to move to the start positions
@@ -264,7 +267,9 @@ class PmacChildPart(builtin.parts.ChildPart):
         self.profile = dict(
             timeArray=[],
             velocityMode=[],
-            userPrograms=[])
+            userPrograms=[],
+        )
+        self.time_since_last_pvt = 0
         for info in self.axis_mapping.values():
             self.profile[info.cs_axis.lower()] = []
         self.calculate_generator_profile(completed_steps, do_run_up=True)
@@ -468,6 +473,66 @@ class PmacChildPart(builtin.parts.ChildPart):
             cs_axis = self.axis_mapping[k].cs_axis.lower()
             self.profile[cs_axis].append(v)
 
+    def add_generator_point_pair(self, point, num, next_point, is_final_point,
+                                 points_are_joined):
+        # Add position
+        user_program = self.get_user_program(PointType.MID_POINT)
+        self.add_profile_point(
+            point.duration / 2.0, PREV_TO_NEXT, user_program, num,
+            {name: point.positions[name] for name in self.axis_mapping})
+
+        # If there will be more frames, insert next live frame
+        if not is_final_point:
+            # insert the lower bound of the next frame if required
+            if points_are_joined:
+                user_program = self.get_user_program(PointType.POINT_JOIN)
+                velocity_point = PREV_TO_NEXT
+            else:
+                user_program = self.get_user_program(PointType.END_OF_ROW)
+                velocity_point = PREV_TO_CURRENT
+
+            self.add_profile_point(
+                point.duration / 2.0, velocity_point, user_program, num + 1,
+                {name: point.upper[name] for name in self.axis_mapping})
+
+            if not points_are_joined:
+                self.insert_gap(point, next_point, num + 1)
+        else:
+            # No more frames, dead frame to finish
+            user_program = self.get_user_program(PointType.END_OF_ROW)
+            self.add_profile_point(
+                point.duration / 2.0, PREV_TO_CURRENT, user_program, num + 1,
+                {name: point.upper[name] for name in self.axis_mapping})
+
+    def add_sparse_point_pair(
+            self, point, num, next_point, is_final_point, points_are_joined):
+        pvt_point = None
+        if not is_final_point:
+            if points_are_joined:
+                # skip this point TODO more logic required for non linear
+                self.time_since_last_pvt += point.interval
+            else:
+                user_program = self.get_user_program(PointType.END_OF_ROW)
+                velocity_point = PREV_TO_CURRENT
+                self.add_profile_point(
+                    self.time_since_last_pvt, velocity_point,
+                    user_program, num + 1,
+                    {name: point.upper[name] for name in self.axis_mapping})
+
+            if not points_are_joined:
+                self.insert_gap(point, next_point, num + 1)
+        else:
+            # No more frames, dead frame to finish
+            user_program = self.get_user_program(PointType.END_OF_ROW)
+            self.add_profile_point(
+                self.time_since_last_pvt,
+                PREV_TO_CURRENT, user_program, num + 1,
+                {name: point.upper[name] for name in self.axis_mapping}
+            )
+            self.time_since_last_pvt = 0
+
+        return pvt_point
+
     def calculate_generator_profile(self, start_index, do_run_up=False):
         # If we are doing the first build, do_run_up will be passed to flag
         # that we need a run up, else just continue from the previous point
@@ -490,40 +555,33 @@ class PmacChildPart(builtin.parts.ChildPart):
                 run_up_time, CURRENT_TO_NEXT, user_program, start_index,
                 axis_points)
 
+        self.time_since_last_pvt = 0
         for i in range(start_index, self.steps_up_to):
             point = self.generator.get_point(i)
 
-            # Add position
-            user_program = self.get_user_program(PointType.MID_POINT)
-            self.add_profile_point(
-                point.duration / 2.0, PREV_TO_NEXT, user_program, i,
-                {name: point.positions[name] for name in self.axis_mapping})
-
-            # If there will be more frames, insert next live frame
             if i + 1 < self.steps_up_to:
                 # Check if we need to insert the lower bound of next_point
                 next_point = self.generator.get_point(i + 1)
                 points_are_joined = points_joined(
-                    self.axis_mapping, point, next_point)
-
-                if points_are_joined:
-                    user_program = self.get_user_program(PointType.POINT_JOIN)
-                    velocity_point = PREV_TO_NEXT
-                else:
-                    user_program = self.get_user_program(PointType.END_OF_ROW)
-                    velocity_point = PREV_TO_CURRENT
-                self.add_profile_point(
-                    point.duration / 2.0, velocity_point, user_program, i + 1,
-                    {name: point.upper[name] for name in self.axis_mapping})
-
-                if not points_are_joined:
-                    self.insert_gap(point, next_point, i + 1)
+                    self.axis_mapping, point, next_point
+                )
+                is_final_point = False
             else:
-                # No more frames, dead frame to finish
-                user_program = self.get_user_program(PointType.END_OF_ROW)
-                self.add_profile_point(
-                    point.duration / 2.0, PREV_TO_CURRENT, user_program, i + 1,
-                    {name: point.upper[name] for name in self.axis_mapping})
+                is_final_point = True
+                points_are_joined = False
+                next_point = None
+
+            if self.output_triggers == scanning.infos.MotionTrigger.EVERY_POINT:
+                self.add_generator_point_pair(
+                    point, i, next_point, is_final_point, points_are_joined
+                )
+            else:
+                self.add_generator_point_pair(
+                    point, i, next_point, is_final_point, points_are_joined
+                )
+                # self.add_sparse_point_pair(
+                #     point, i, next_point, is_final_point, points_are_joined
+                # )
 
             # Check if we have exceeded the points number and need to write
             # Strictly less than so we always add one more point to the time

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -1,19 +1,15 @@
+from os import environ
+
 import numpy as np
 import pytest
-from mock import Mock, call, patch, ANY
-from scanpointgenerator import LineGenerator, CompoundGenerator, \
-    StaticPointGenerator
-
 from malcolm.core import Context, Process
 from malcolm.modules.pmac.parts import PmacChildPart
 from malcolm.modules.scanning.infos import MotionTrigger, MotionTriggerInfo
 from malcolm.testutil import ChildTestCase
 from malcolm.yamlutil import make_block_creator
-
-SHOW_GRAPHS = False
-# Uncomment this to show graphs when running under PyCharm
-# SHOW_GRAPHS = "PYCHARM_HOSTED" in os.environ
-
+from mock import Mock, call, patch, ANY
+from scanpointgenerator import LineGenerator, CompoundGenerator, \
+    StaticPointGenerator
 
 
 class TestPMACChildPart(ChildTestCase):
@@ -96,64 +92,93 @@ class TestPMACChildPart(ChildTestCase):
         expected = 0.010166
         assert ret.value.duration == expected
 
-    def do_check_output(self, user_programs=None, turnaround=200000):
+    def do_check_output(self, user_programs=None):
         if user_programs is None:
             user_programs = [
-                       1, 4, 1, 4, 1, 4, 2, 8, 1, 4, 1, 4, 1, 4, 2, 8]
-        assert self.child.handled_requests.mock_calls == [
+                1, 4, 1, 4, 1, 4, 2, 8, 8, 8, 1, 4, 1, 4, 1, 4, 2, 8
+            ]
+        # use a slice here because I'm getting calls to __str__ in debugger
+        assert self.child.handled_requests.mock_calls[:4] == [
             call.post('writeProfile',
                       csPort='CS1', timeArray=[0.002], userPrograms=[8]),
             call.post('executeProfile'),
             call.post('moveCS1', a=-0.1375, b=0.0, moveTime=1.0375),
             # pytest.approx to allow sensible compare with numpy arrays
             call.post('writeProfile',
+                      a=pytest.approx(
+                          [-0.125, 0., 0.125, 0.25, 0.375, 0.5, 0.625, 0.6375,
+                           0.6375, 0.6375, 0.625, 0.5, 0.375, 0.25, 0.125, 0.,
+                           -0.125, -0.1375]),
+                      b=pytest.approx(
+                          [0., 0., 0., 0., 0., 0., 0., 0.0125, 0.05, 0.0875,
+                           0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
                       csPort='CS1',
-                      a=pytest.approx([
-                       -0.125, 0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.6375,
-                       0.625, 0.5, 0.375, 0.25, 0.125, 0.0, -0.125, -0.1375]),
-                      b=pytest.approx([
-                       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05,
-                       0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
-                      timeArray=pytest.approx([
-                       100000, 500000, 500000, 500000, 500000, 500000, 500000,
-                       turnaround, turnaround, 500000, 500000, 500000, 500000,
-                       500000, 500000, 100000]),
+                      timeArray=pytest.approx(
+                          [100000, 500000, 500000, 500000, 500000, 500000,
+                           500000, 100000, 100000, 100000, 100000, 500000,
+                           500000, 500000, 500000, 500000, 500000, 100000]),
                       userPrograms=pytest.approx(user_programs),
-                      velocityMode=pytest.approx([
-                       2, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 1, 3])
+                      velocityMode=pytest.approx(
+                          [1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0,
+                           0, 0, 1, 3])
                       )
-            ]
+        ]
         assert self.o.completed_steps_lookup == [
-            0, 0, 1, 1, 2, 2, 3, 3,
+            0, 0, 1, 1, 2, 2, 3, 3, 3, 3,
             3, 3, 4, 4, 5, 5, 6, 6]
 
-    @patch("malcolm.modules.pmac.parts.pmacchildpart.INTERPOLATE_INTERVAL",
-           0.2)
+    def do_check_output_slower(self):
+        # use a slice here because I'm getting calls to __str__ in debugger
+        assert self.child.handled_requests.mock_calls[:4] == [
+            call.post('writeProfile', csPort='CS1', timeArray=[0.002],
+                      userPrograms=[8]),
+            call.post('executeProfile'),
+            call.post('moveCS1', a=-0.1375, b=0.0, moveTime=1.0375),
+            call.post('writeProfile',
+                      a=pytest.approx(
+                          [-0.125, 0., 0.125, 0.25, 0.375, 0.5, 0.625, 0.6375,
+                           0.6375, 0.6375, 0.6375, 0.625, 0.5, 0.375, 0.25,
+                           0.125, 0., -0.125, -0.1375]),
+                      b=pytest.approx(
+                          [0., 0., 0., 0., 0., 0., 0., 0.00125, 0.02, 0.08,
+                           0.09875, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
+                      csPort='CS1',
+                      timeArray=pytest.approx(
+                          [100000, 500000, 500000, 500000, 500000, 500000,
+                           500000, 100000, 300000, 600000, 300000, 100000,
+                           500000, 500000, 500000, 500000, 500000, 500000,
+                           100000]),
+                      userPrograms=pytest.approx(
+                          [1, 4, 1, 4, 1, 4, 2, 8, 8, 8, 8, 1, 4, 1, 4, 1, 4,
+                           2, 8]),
+                      velocityMode=pytest.approx(
+                          [1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1,
+                           3])
+                      )
+        ]
+        assert self.o.completed_steps_lookup == [
+            0, 0, 1, 1, 2, 2, 3, 3, 3, 3, 3,
+            3, 3, 4, 4, 5, 5, 6, 6]
+
     def test_configure(self):
         self.do_configure(axes_to_scan=["x", "y"])
         self.do_check_output()
 
-    @patch("malcolm.modules.pmac.parts.pmacchildpart.INTERPOLATE_INTERVAL",
-           0.2)
     def test_configure_slower_vmax(self):
-        self.set_attributes(self.child_y, maxVelocityPercent=49.4)
+        self.set_attributes(self.child_y, maxVelocityPercent=10)
         self.do_configure(axes_to_scan=["x", "y"])
-        self.do_check_output(turnaround=284555)
+        self.do_check_output_slower()
 
-    @patch("malcolm.modules.pmac.parts.pmacchildpart.INTERPOLATE_INTERVAL",
-           0.2)
     def test_configure_no_pulses(self):
         self.do_configure(axes_to_scan=["x", "y"],
                           infos=[MotionTriggerInfo(MotionTrigger.NONE)])
-        self.do_check_output(user_programs=[0]*16)
+        self.do_check_output(user_programs=[0]*18)
 
-    @patch("malcolm.modules.pmac.parts.pmacchildpart.INTERPOLATE_INTERVAL",
-           0.2)
     def test_configure_start_of_row_pulses(self):
         self.do_configure(axes_to_scan=["x", "y"],
                           infos=[MotionTriggerInfo(MotionTrigger.ROW_GATE)])
         self.do_check_output(user_programs=[
-                       1, 0, 0, 0, 0, 0, 8, 0, 1, 0, 0, 0, 0, 0, 8, 0])
+                       1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 8, 0])
 
     def test_configure_no_axes(self):
         self.set_motor_attributes()
@@ -174,14 +199,12 @@ class TestPMACChildPart(ChildTestCase):
                       userPrograms=pytest.approx([
                           1, 4, 1, 4, 1, 4, 1, 4, 1, 4, 1, 4, 2, 8]),
                       velocityMode=pytest.approx([
-                          2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
+                          1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
             ]
         assert self.o.completed_steps_lookup == [
             0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6]
 
     @patch("malcolm.modules.pmac.parts.pmacchildpart.PROFILE_POINTS", 4)
-    @patch("malcolm.modules.pmac.parts.pmacchildpart.INTERPOLATE_INTERVAL",
-           0.2)
     def test_update_step(self):
         self.do_configure(axes_to_scan=["x", "y"], x_pos=0.0, y_pos=0.2)
         assert len(self.child.handled_requests.mock_calls) == 4
@@ -203,16 +226,16 @@ class TestPMACChildPart(ChildTestCase):
             # pytest.approx to allow sensible compare with numpy arrays
             call.post('writeProfile',
                       a=pytest.approx([0.375, 0.5, 0.625, 0.6375]),
-                      b=pytest.approx([0.0, 0.0, 0.0, 0.05]),
+                      b=pytest.approx([0.0, 0.0, 0.0, 0.0125]),
                       timeArray=pytest.approx([
-                          500000, 500000, 500000, 200000]),
+                          500000, 500000, 500000, 100000]),
                       userPrograms=pytest.approx([1, 4, 2, 8]),
-                      velocityMode=pytest.approx([0, 0, 1, 0])
+                      velocityMode=pytest.approx([0, 0, 1, 1])
             )
         ]
         assert self.o.end_index == 3
-        assert len(self.o.completed_steps_lookup) == 9
-        assert len(self.o.profile["timeArray"]) == 1
+        assert len(self.o.completed_steps_lookup) == 11
+        assert len(self.o.profile["timeArray"]) == 3
 
     def test_run(self):
         self.o.generator = ANY
@@ -247,11 +270,9 @@ class TestPMACChildPart(ChildTestCase):
                     100000, 500000, 500000, 500000, 500000, 500000, 500000,
                     100000]),
                 userPrograms=pytest.approx([1, 4, 1, 4, 1, 4, 2, 8]),
-                velocityMode=pytest.approx([2, 0, 0, 0, 0, 0, 1, 3])),
+                velocityMode=pytest.approx([1, 0, 0, 0, 0, 0, 1, 3])),
             ]
 
-    @patch("malcolm.modules.pmac.parts.pmacchildpart.INTERPOLATE_INTERVAL",
-           0.2)
     def test_long_steps_lookup(self):
         self.do_configure(
             axes_to_scan=["x"], completed_steps=3, x_pos=0.62506, duration=14.0)
@@ -269,7 +290,7 @@ class TestPMACChildPart(ChildTestCase):
             userPrograms=pytest.approx([
                 1, 0, 4, 0, 1, 0, 4, 0, 1, 0, 4, 0, 2, 8]),
             velocityMode=pytest.approx([
-                2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]))
         assert self.o.completed_steps_lookup == (
             [3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6])
 
@@ -292,7 +313,7 @@ class TestPMACChildPart(ChildTestCase):
             userPrograms=pytest.approx([
                 1, 0, 4, 0, 1, 0, 4, 0, 1]),
             velocityMode=pytest.approx([
-                2, 0, 0, 0, 0, 0, 0, 0, 0]))
+                1, 0, 0, 0, 0, 0, 0, 0, 0]))
         # The completed steps works on complete (not split) steps, so we expect
         # the last value to be the end of step 6, even though it doesn't
         # actually appear in the velocity arrays
@@ -323,45 +344,15 @@ class TestPMACChildPart(ChildTestCase):
         assert self.o.completed_steps_lookup == (
             [3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6])
 
-    def turnaround_overshoot(
-            self, go_really_fast=False, title='', points=30):
-        """ check for a previous bug in a sawtooth X,Y scan
-        The issue was that the first point at the start of each rising edge
-        overshot in Y. The parameters for each rising edge are below.
+    def do_2d_trajectory_with_plot(self, gen, xv, yv, xa, ya, title):
+        gen.prepare()
 
-        Line Y, start=-2.5, stop= -2.5 +0.025, points=30
-        Line X, start=-0.95, stop= -0.95 +0.025, points=30
-        duration=0.15
-
-        X motor: VMAX=17, ACCL=0.1 (time to VMAX)
-        Y motor: VMAX=1, ACCL=0.2
-        """
-        x = -2.5
-        y = -.95
-        p = points  # set to 30 for Tom's original numbers
-        d = .025 * p / 30
-        xs = LineGenerator("x", "mm", x, x + d, p)
-        ys = LineGenerator("y", "mm", y, y + d, p)
-        # Toms original parameters below
-        # xs = LineGenerator("x", "mm", -2.5, -2.475, 30)
-        # ys = LineGenerator("y", "mm", -0.95, -0.925, 30)
-
-        generator = CompoundGenerator([ys, xs], [], [], 0.15)
-        generator.prepare()
-
-        if go_really_fast:
-            self.set_motor_attributes(
-                x_acceleration=17.0 / 0.1, y_acceleration=1. / 0.2,
-                x_velocity=17, y_velocity=1,
-                x_pos=-2.5, y_pos=-.95)
-        else:
-            self.set_motor_attributes(
-                x_acceleration=1. / 0.1, y_acceleration=1. / 0.2,
-                x_velocity=17, y_velocity=1,
-                x_pos=-2.5, y_pos=-.95)
+        self.set_motor_attributes(
+            x_acceleration=xv / xa, y_acceleration=yv / ya,
+            x_velocity=xv, y_velocity=yv)
 
         infos = [MotionTriggerInfo(MotionTrigger.ROW_GATE)]
-        infos = [MotionTriggerInfo(MotionTrigger.EVERY_POINT)]
+        # infos = [MotionTriggerInfo(MotionTrigger.EVERY_POINT)]
         self.o.configure(self.context, 0, gen.size,
                          {"part": infos},
                          gen, ["x", "y"])
@@ -383,23 +374,32 @@ class TestPMACChildPart(ChildTestCase):
 
         # if this test is run in pycharm then it plots some results
         # to help diagnose issues
-        if SHOW_GRAPHS:
+        if environ.get("PLOTS") == '1':
             import matplotlib.pyplot as plt
-            # plt.title("{} x/y {} points".format(title, xp.size))
-            # plt.plot(xp, yp, '+', ms=2.5)
-            # plt.show()
-
-            # plt.title("{} x/point {} points".format(title, xp.size))
-            # plt.plot(xp, range(xp.size), '+', ms=2.5)
-            # plt.show()
 
             times = np.cumsum(tp / 1000)  # show in millisecs
-            plt.title("{} x/time {} points".format(title, xp.size))
 
+            fig1 = plt.figure(figsize=(8, 6), dpi=300)
+            plt.title("{} x/time {} points".format(title, xp.size))
             plt.plot(xp, times, '+', ms=2.5)
+            fig2 = plt.figure(figsize=(8, 6), dpi=300)
+            plt.title("{} x/y".format(title))
+            plt.plot(xp, yp, '+', ms=2.5)
             plt.show()
 
-        return xp
+        return xp, yp
+
+    def check_bounds(self, a, name):
+        # tiny amounts of overshoot are acceptable
+        npa = np.array(a)
+        less_start = np.argmax((npa[0] - npa) > 0.000001)
+        greater_end = np.argmax((npa - npa[-1]) > 0.000001)
+        self.assertEqual(
+            less_start, 0, "Position {} < start for {}\n{}".format(
+                less_start, name, a))
+        self.assertEqual(
+            greater_end, 0, "Position {} > end for {}\n{}".format(
+                greater_end, name, a))
 
     def test_turnaround_overshoot(self):
         """ check for a previous bug in a sawtooth X,Y scan
@@ -423,15 +423,14 @@ class TestPMACChildPart(ChildTestCase):
             generator, xv=17, yv=1, xa=.1, ya=.2,
             title='test_turnaround_overshoot 10 fast')
         self.child.handled_requests.reset_mock()
-        x2 = self.turnaround_overshoot(
-            go_really_fast=True,
-            title='test_turnaround_overshoot 10 fast',
-            points=30)
+
+        x2, y2 = self.do_2d_trajectory_with_plot(
+            generator, xv=17, yv=34, xa=10, ya=.1,
+            title='test_turnaround_overshoot 10 slower')
         self.child.handled_requests.reset_mock()
 
-        # checks that the two turnarounds only contain points
-        # between the first line end and the second line start
-        assert x2[61] > x2[62] > x2[63], \
-            "Bad turnaround point in fast profile"
-        assert x1[61] > x1[62] > x1[63] > x1[64] > x1[65] > x1[66], \
-            "Bad turnaround point in slow profile"
+        # check all the points in the arrays are within their start and stop
+        self.check_bounds(x1, "x1")
+        self.check_bounds(x2, "x2")
+        self.check_bounds(y1, "y1")
+        self.check_bounds(y2, "y2")


### PR DESCRIPTION
This is OK to merge into master.

It implements the sparse PVT points when 'start of row' triggering is requested. It only works for linear rows but does not break non-linear rows (it just creates the same PVT points as before the change).

This branch is now separate from velocity-mode-changes and so it still works with the current version of the trajectory PROG.

