### PR TITLE
Add axisNumber attribute to RawMotorSinkPortsPart

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Added:
 
 - maxVelocityPercent added to motors. Allows turnaround times to be tweaked
   without changing VMAX
+- axisNumber attribute to
 
 `4-0`_ - 2019-07-05
 -------------------

--- a/tests/test_modules/test_pmac/test_rawmotorsinkportspart.py
+++ b/tests/test_modules/test_pmac/test_rawmotorsinkportspart.py
@@ -42,9 +42,11 @@ class TestRawMotorSinkPortsPart(unittest.TestCase):
              "PV:PRE:CsAxis_RBV", "PV:PRE.OUT"],
             format=catools.FORMAT_CTRL)
         assert list(self.b) == [
-            'meta', 'health', 'state', 'disable', 'reset', "pmac", 'cs']
+            'meta', 'health', 'state', 'disable',
+            'reset', "pmac", 'axisNumber', 'cs']
         assert self.b.cs.value == "BRICK1CS1,A"
         assert self.b.pmac.value == "PMAC"
+        assert self.b.axisNumber.value == 1
 
     def test_update_axis(self, catools):
         self.do_init(catools)


### PR DESCRIPTION
This adds the axisNumber attribute to the Raw Motor Sink Ports Part.
It can be accessed in the same way that the "cs" attribute is used to get the CS.