### PR TITLE
Changed name of secondary datasource to by dynamically set to name of…

### DIFF
--- a/malcolm/modules/ADOdin/parts/odinwriterpart.py
+++ b/malcolm/modules/ADOdin/parts/odinwriterpart.py
@@ -51,7 +51,7 @@ def create_dataset_infos(name, generator, filename, secondary_set):
 
     # Add other datasources
     yield scanning.infos.DatasetProducedInfo(
-        name="%s.uid" % name,
+        name="%s.%s" % (name, secondary_set),
         filename=filename,
         type=scanning.infos.DatasetType.SECONDARY,
         rank=generator_rank + 2,


### PR DESCRIPTION
… secondary_set

I believe this is correct, but I can test on J13 to confirm this fix during shutdown (it was hard-coded for Monday's tests). Otherwise the current behaviour is the secondary source has the name of uid regardless of what data is stored.