### PR TITLE
Quantization fix

### DIFF
--- a/malcolm/modules/pmac/infos.py
+++ b/malcolm/modules/pmac/infos.py
@@ -1,9 +1,6 @@
 # Treat all division as float division even in python2
 from __future__ import division
 
-import numpy as np
-import math
-
 from malcolm.core import Info
 from .velocityprofile import VelocityProfile
 
@@ -12,7 +9,7 @@ class MotorInfo(Info):
     def __init__(self,
                  cs_axis,  # type: str
                  cs_port,  # type: str
-                 acceleration,   # type: float
+                 acceleration,  # type: float
                  resolution,  # type: float
                  offset,  # type: float
                  max_velocity,  # type: float
@@ -45,7 +42,8 @@ class MotorInfo(Info):
         ramp_distance = (v1 + v2) * ramp_time / 2
         return ramp_distance
 
-    def make_velocity_profile(self, v1, v2, distance, min_time):
+    def make_velocity_profile(
+            self, v1, v2, distance, min_time, min_interval=0.002):
         """Calculate PVT points that will perform the move within motor params
 
         Args:
@@ -53,14 +51,16 @@ class MotorInfo(Info):
             v2 (float): Ending velocity in EGUs/s
             distance (float): Relative distance to travel in EGUs
             min_time (float): The minimum time the move should take
+            min_interval (float): Minimum time between profile points
 
         Returns:
             VelocityProfile: defining a list of times and velocities
         """
 
         # Create the time and velocity arrays
-        p = VelocityProfile(v1, v2, distance, min_time, self.acceleration,
-                            self.max_velocity, self.velocity_settle)
+        p = VelocityProfile(
+            v1, v2, distance, min_time, self.acceleration, self.max_velocity,
+            self.velocity_settle, min_interval)
         p.get_profile()
         return p
 
@@ -69,4 +69,3 @@ class MotorInfo(Info):
         """Return the position (in EGUs) translated to counts"""
         cts = int(round((position - self.offset) / self.resolution))
         return cts
-

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -390,7 +390,7 @@ class PmacChildPart(builtin.parts.ChildPart):
 
     def calculate_profile_from_velocities(self, time_arrays, velocity_arrays,
                                           current_positions, completed_steps):
-        # at this point we have time/velocity arrays with 5-7 values for each
+        # at this point we have time/velocity arrays with 2-4 values for each
         # axis. Each time represents a (instantaneous) change in acceleration.
         # We want to translate this into a move profile (time/position).
         # Every axis profile must have a point for each of the times from
@@ -641,6 +641,13 @@ class PmacChildPart(builtin.parts.ChildPart):
         # Work out the Position trajectories from these profiles
         self.calculate_profile_from_velocities(
             time_arrays, velocity_arrays, start_positions, completed_steps)
+
+        # make sure the last point is the same as next_point.lower since
+        # calculate_profile_from_velocities fails when the turnaround is 2
+        # points only
+        for axis_name, motor_info in self.axis_mapping.items():
+            self.profile[motor_info.cs_axis.lower()][-1] = \
+                next_point.lower[axis_name]
 
         # Change the last point to be a live frame
         self.profile["velocityMode"][-1] = PREV_TO_CURRENT

--- a/malcolm/modules/pmac/util.py
+++ b/malcolm/modules/pmac/util.py
@@ -19,8 +19,10 @@ if TYPE_CHECKING:
 # All possible PMAC CS axis assignment
 CS_AXIS_NAMES = list("ABCUVWXYZ")
 
-# Minimum move time for any move
+# Minimum move time for a whole profile
 MIN_TIME = 0.002
+# minimum time between points in a profile
+MIN_INTERVAL = 0.002
 
 
 def cs_port_with_motors_in(context,  # type: Context
@@ -140,8 +142,13 @@ def point_velocities(axis_mapping, point, entry=True):
     return velocities
 
 
-def profile_between_points(axis_mapping, point, next_point, min_time=MIN_TIME):
-    # type: (Dict[str, MotorInfo], Point, Point, float) -> Tuple[Profiles, Profiles]
+def profile_between_points(
+        axis_mapping,  # type: (Dict[str, MotorInfo])
+        point,  # type: Point
+        next_point,  # type: Point
+        min_time=MIN_TIME,  # type: float
+        min_interval=MIN_INTERVAL  # type: float
+):
     """Make consistent time and velocity arrays for each axis
 
     Try to create velocity profiles for all axes that all arrive at
@@ -185,7 +192,7 @@ def profile_between_points(axis_mapping, point, next_point, min_time=MIN_TIME):
             distance = next_point.lower[axis_name] - point.upper[axis_name]
             p = motor_info.make_velocity_profile(
                 start_velocities[axis_name], end_velocities[axis_name],
-                distance, min_time
+                distance, min_time, min_interval
             )
             # Absolute time values that we are at that velocity
             profiles[axis_name] = p

--- a/malcolm/modules/pmac/velocityprofile.py
+++ b/malcolm/modules/pmac/velocityprofile.py
@@ -386,9 +386,11 @@ class VelocityProfile:
         Returns bool: true if this profile requires quantization:
         """
         times = np.array([self.t1, self.tm, self.t2])
-        decimals = (times / self.interval) % 1
-        result = not np.isclose(decimals, np.round(decimals)).all()
-        return result
+        # don't quantize profiles that are shorter than interval
+        if self.tv2 > self.interval:
+            decimals = (times / self.interval) % 1
+            result = not np.isclose(decimals, np.round(decimals)).all()
+            return result
 
     def quantize(self):
         """
@@ -454,7 +456,12 @@ class VelocityProfile:
         :Returns Array(float), Array(float): absolute time, velocity arrays
         """
         # return ABSOLUTE time and velocity arrays to describe the profile
-        if self.d == 0 and self.v1 == 0 and self.v2 == 0:
+        if self.tv2 <= self.interval:
+            # for profiles that are shorter than the min interval
+            # we only return the start and end with no mid points
+            time_array = [0.0, self.tv2]
+            velocity_array = [self.v1, self.v2]
+        elif self.d == 0 and self.v1 == 0 and self.v2 == 0:
             time_array = [0.0, self.tv2]
             velocity_array = [0, 0]
         else:

--- a/malcolm/modules/pmac/velocityprofile.py
+++ b/malcolm/modules/pmac/velocityprofile.py
@@ -451,11 +451,15 @@ class VelocityProfile:
         :Returns Array(float), Array(float): absolute time, velocity arrays
         """
         # return ABSOLUTE time and velocity arrays to describe the profile
-        time_array = [0.0, self.t1, self.tv2]
-        velocity_array = [self.v1, self.vm, self.v2]
-        if self.tm > 0:
-            time_array.insert(2, self.t1 + self.tm)
-            velocity_array.insert(2, self.vm)
+        if self.d == 0 and self.v1 == 0 and self.v2 == 0:
+            time_array = [0.0, self.tv2]
+            velocity_array = [self.v1, self.v2]
+        else:
+            time_array = [0.0, self.t1, self.tv2]
+            velocity_array = [self.v1, self.vm, self.v2]
+            if self.tm > 0:
+                time_array.insert(2, self.t1 + self.tm)
+                velocity_array.insert(2, self.vm)
         if self.settle_time > 0:
             time_array.append(time_array[-1] + self.settle_time)
             velocity_array.append(self.v2)

--- a/malcolm/modules/pmac/velocityprofile.py
+++ b/malcolm/modules/pmac/velocityprofile.py
@@ -11,7 +11,7 @@ R_TOL = 1e-10
 
 
 class VelocityProfile:
-    """
+    r"""
     Generate a velocity profile that starts at v1 and finishes at v2 in time t
     and travels distance d for a motor with acceleration a and maximum velocity
     v_max.
@@ -103,7 +103,7 @@ class VelocityProfile:
         assert v_max > 0 and a > 0, "v_max, acceleration must be > 0"
 
     def check_range(self):
-        """
+        r"""
         Calculate the positive and negative velocity maxima attainable between
         v1 and v2 within time tv2. This allows the calculations of the maximum
         and minimum distance attainable. It deliberately ignores v_max so that
@@ -236,7 +236,7 @@ class VelocityProfile:
                 self.tv2 += (dc - self.d) / self.v_max
 
     def calculate_vm(self):
-        """
+        r"""
         to ensure this function will succeed, call stretch_time() first.
 
         Once we have adjusted tv2 to ensure that d is attainable we can now

--- a/malcolm/modules/pmac/velocityprofile.py
+++ b/malcolm/modules/pmac/velocityprofile.py
@@ -66,7 +66,7 @@ class VelocityProfile:
             a,  # type: float
             v_max,  # type: float
             settle_time=0,  # type: float
-            interval=0.002  # type: float
+            interval=0  # type: float
     ):  # type: (...) -> None
         """
         Initialize the properties that define the desired profile
@@ -387,7 +387,7 @@ class VelocityProfile:
         """
         times = np.array([self.t1, self.tm, self.t2])
         # don't quantize profiles that are shorter than interval
-        if self.tv2 > self.interval:
+        if self.tv2 > self.interval > 0:
             decimals = (times / self.interval) % 1
             result = not np.isclose(decimals, np.round(decimals)).all()
             return result

--- a/malcolm/modules/pmac/velocityprofile.py
+++ b/malcolm/modules/pmac/velocityprofile.py
@@ -453,7 +453,7 @@ class VelocityProfile:
         # return ABSOLUTE time and velocity arrays to describe the profile
         if self.d == 0 and self.v1 == 0 and self.v2 == 0:
             time_array = [0.0, self.tv2]
-            velocity_array = [self.v1, self.v2]
+            velocity_array = [0, 0]
         else:
             time_array = [0.0, self.t1, self.tv2]
             velocity_array = [self.v1, self.vm, self.v2]

--- a/malcolm/modules/scanning/infos.py
+++ b/malcolm/modules/scanning/infos.py
@@ -70,10 +70,12 @@ class MinTurnaroundInfo(Info):
 
     Args:
         gap: The minimum time gap in seconds
+        interval: the minimum interval between two turnaround points
     """
-    def __init__(self, gap):
-        # type: (float) -> None
+    def __init__(self, gap, interval):
+        # type: (float, float) -> None
         self.gap = gap
+        self.interval = interval
 
 
 class DatasetProducedInfo(Info):

--- a/malcolm/modules/scanning/parts/minturnaroundpart.py
+++ b/malcolm/modules/scanning/parts/minturnaroundpart.py
@@ -7,26 +7,35 @@ from ..infos import MinTurnaroundInfo
 
 with Anno("Initial value for min time between non-joined points"):
     AMinTurnaround = float
+with Anno("Minimum interval between turnaround points"):
+    ATurnaroundInterval = float
 
 
 class MinTurnaroundPart(Part):
-    def __init__(self, name="minTurnaround", value=None):
-        # type: (APartName, AMinTurnaround) -> None
+    def __init__(self, name="minTurnaround", gap=None, interval=None):
+        # type: (APartName, AMinTurnaround, ATurnaroundInterval) -> None
         super(MinTurnaroundPart, self).__init__(name)
-        self.attr = NumberMeta(
+        self.gap = NumberMeta(
             "float64", "Minimum time for any gaps between non-joined points",
             tags=[Widget.TEXTINPUT.tag(), config_tag()],
             display=Display(precision=6, units="s")
-        ).create_attribute_model(value)
+        ).create_attribute_model(gap)
+        self.interval = NumberMeta(
+            "float64", "Minimum interval between turnaround points",
+            tags=[Widget.TEXTINPUT.tag(), config_tag()],
+            display=Display(precision=6, units="s")
+        ).create_attribute_model(interval)
 
     @add_call_types
     def report_status(self):
         # type: () -> UInfos
-        return MinTurnaroundInfo(self.attr.value)
+        return MinTurnaroundInfo(self.gap.value, self.interval.value)
 
     def setup(self, registrar):
         # type: (PartRegistrar) -> None
         registrar.add_attribute_model(
-            "minTurnaround", self.attr, self.attr.set_value)
+            "minTurnaround", self.gap, self.gap.set_value)
+        registrar.add_attribute_model(
+            "minTurnaroundInterval", self.interval, self.interval.set_value)
         # Hooks
         registrar.hook(ReportStatusHook, self.report_status)

--- a/tests/test_modules/test_pmac/test_motorinfo.py
+++ b/tests/test_modules/test_pmac/test_motorinfo.py
@@ -54,7 +54,7 @@ class TestMotorPVT(unittest.TestCase):
         distance = 0.1
         self.o.velocity_settle = 0.1
         p = self.o.make_velocity_profile(
-            v1, v2, distance, 0.0)
+            v1, v2, distance, 0.0, 0.001)
         p.quantize()
         time_array, velocity_array = p.make_arrays()
         self.check_distance(distance, time_array, velocity_array)

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -557,8 +557,29 @@ class TestPMACChildPart(ChildTestCase):
 
         action, func, args = self.child.handled_requests.mock_calls[-1]
         assert args['a'] == \
-            pytest.approx([0, 0, 0, 0, .0001, .0001, .0001])
+            pytest.approx([0, 0, 0, .0001, .0001, .0001, .0001])
         assert args['b'] == \
             pytest.approx([0, 0, 0, 0, 0, 0, 0])
         assert args['timeArray'] == pytest.approx(
             [2000, 2500, 2500, 2000, 2500, 2500, 2000])
+
+        # now make the acceleration slower so that the turnaround takes
+        # longer than the minimum interval
+        self.set_motor_attributes(
+            0.0, 0.0, "mm", x_acceleration=10., x_velocity=2.,
+            y_acceleration=100., y_velocity=2.)
+
+        self.o.configure(
+            self.context, 0, steps_to_do, {"part": m},
+            generator, axes_to_scan)
+
+        # this generates one mid point between the 1st upper and 2nd lower
+        # bounds. Note that the point is not exactly central due to time
+        # quantization
+        action, func, args = self.child.handled_requests.mock_calls[-1]
+        assert args['a'] == \
+            pytest.approx([0, 0, 0, 5.45454545e-05, .0001, .0001, .0001, .0001])
+        assert args['b'] == \
+            pytest.approx([0, 0, 0, 0, 0, 0, 0, 0])
+        assert args['timeArray'] == pytest.approx(
+            [2000, 2500, 2500, 6000, 5000, 2500, 2500, 2000])

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -496,3 +496,36 @@ class TestPMACChildPart(ChildTestCase):
         self.check_bounds(x2, "x2")
         self.check_bounds(y1, "y1")
         self.check_bounds(y2, "y2")
+
+    def test_step_scan(self):
+        axes_to_scan = ["x", "y"]
+        duration = 1.0005
+        self.set_motor_attributes(0.0, 0.0, "mm")
+        steps_to_do = 3 * len(axes_to_scan)
+        xs = LineGenerator("x", "mm", 0.0, 5, 3, alternate=True)
+        ys = LineGenerator("y", "mm", 0.0, 10, 2)
+        generator = CompoundGenerator(
+            [ys, xs], [], [], duration, continuous=False)
+        generator.prepare()
+
+        self.o.configure(
+            self.context, 0, steps_to_do, {"part": None},
+            generator, axes_to_scan)
+
+        assert self.child.handled_requests.mock_calls[3].kwargs['a'] == \
+               pytest.approx([
+                   0.0, 0.0, 0.0, 0.2, 2.3, 2.5, 2.5, 2.5, 2.7, 4.8, 5.0, 5.0,
+                   5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 4.8, 2.7, 2.5, 2.5, 2.5, 2.3,
+                   0.2, 0, 0.0, 0.0, 0.0])
+        assert self.child.handled_requests.mock_calls[3].kwargs['b'] == \
+               pytest.approx([
+                   0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                   0.0, 0.2, 9.8, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0,
+                   10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0])
+        assert self.child.handled_requests.mock_calls[3].kwargs[
+                   'timeArray'] == pytest.approx([
+                   2000, 500250, 500250, 400000, 2100000, 400000, 500250,
+                   500250, 400000, 2100000, 400000, 500250, 500250, 400000,
+                   9600000, 400000, 500250, 500250, 400000, 2100000, 400000,
+                   500250, 500250, 400000, 2100000, 400000, 500250, 500250,
+                   2000])

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -540,7 +540,8 @@ class TestPMACChildPart(ChildTestCase):
         axes_to_scan = ["x", "y"]
         duration = .005
         self.set_motor_attributes(
-            0.0, 0.0, "mm", x_acceleration=100, x_velocity=2)
+            0.0, 0.0, "mm", x_acceleration=100., x_velocity=2.,
+            y_acceleration=100., y_velocity=2.)
         steps_to_do = 1 * len(axes_to_scan)
 
         xs = LineGenerator("x", "mm", 0, .0001, 2)

--- a/tests/test_modules/test_pmac/test_velocityprofile.py
+++ b/tests/test_modules/test_pmac/test_velocityprofile.py
@@ -42,6 +42,21 @@ class TestPmacStatusPart(unittest.TestCase):
                     d_res, d, profile.vm, profile.v1, profile.v2, profile.tv2)
 
     @staticmethod
+    def do_test_acceleration_range(v1, v2, quantize=False):
+        a = 1000000
+        while a > .001:
+            d = .001
+            profile = VelocityProfile(v1, v2, d, .1, a, 100, 10)
+            profile.get_profile()
+            if quantize:
+                profile.quantize(size=.009)
+            d_res = profile.calculate_distance()
+            assert np.isclose(d_res, d), \
+                "Wrong d({}). Expected d {}, vm {}, v1 {}, v2 {}, t {}".format(
+                    d_res, d, profile.vm, profile.v1, profile.v2, profile.tv2)
+            a /= 10
+
+    @staticmethod
     def do_test_v_max_range(v1, v2):
         ms = np.arange(4, 100, 3)
         for v_max in ms:
@@ -52,6 +67,14 @@ class TestPmacStatusPart(unittest.TestCase):
             assert np.isclose(d_res, 100), \
                 "Wrong d({}). Expected d {}, vm {}, v1 {}, v2 {}, t {}".format(
                     d_res, d, profile.vm, profile.v1, profile.v2, profile.tv2)
+
+    def test_zero_zero(self):
+        self.do_test_acceleration_range(0.0, 0.0, quantize=True)
+        self.do_test_distance_range(0.0, 0.0)
+        self.do_test_distance_range(0.0, 0.0)
+        self.do_test_time_range(0.0, 0.0)
+        self.do_test_time_range(0.0, 0.0, quantize=True)
+        self.do_test_v_max_range(0.0, 0.0)
 
     def test_pos_pos(self):
         self.do_test_distance_range(4.0, 2.0)

--- a/tests/test_modules/test_pmac/test_velocityprofile.py
+++ b/tests/test_modules/test_pmac/test_velocityprofile.py
@@ -46,10 +46,12 @@ class TestPmacStatusPart(unittest.TestCase):
         a = 1000000
         while a > .001:
             d = .001
-            profile = VelocityProfile(v1, v2, d, .1, a, 100, 10)
+            profile = VelocityProfile(
+                v1, v2, d, .1, a, 100, 10, interval=.009
+            )
             profile.get_profile()
             if quantize:
-                profile.quantize(size=.009)
+                profile.quantize()
             d_res = profile.calculate_distance()
             assert np.isclose(d_res, d), \
                 "Wrong d({}). Expected d {}, vm {}, v1 {}, v2 {}, t {}".format(

--- a/tests/test_modules/test_pmac/test_velocityprofile.py
+++ b/tests/test_modules/test_pmac/test_velocityprofile.py
@@ -32,7 +32,7 @@ class TestPmacStatusPart(unittest.TestCase):
             ts = np.arange(.01, 20, .1)
         for t in ts:
             d = 100
-            profile = VelocityProfile(v1, v2, d, t, 2.0, 10000)
+            profile = VelocityProfile(v1, v2, d, t, 2.0, 10000, interval=.002)
             profile.get_profile()
             if quantize:
                 profile.quantize()


### PR DESCRIPTION
This adds configuration of the quantization interval to scanning.parts.MinTurnaroundPart.

However, two of the tests are failing on Travis but not locally. Have you seen this issue? :
```
_______________________ TestPMACChildPart.test_step_scan _______________________
Traceback (most recent call last):
  File "/home/travis/build/dls-controls/pymalcolm/tests/test_modules/test_pmac/test_pmacchildpart.py", line 517, in test_step_scan
    assert self.child.handled_requests.mock_calls[-1].kwargs['a'] == \
TypeError: tuple indices must be integers or slices, not str
```