### PR TITLE
PandASeqTriggerPart: added PostRunArmedHook to configure() to fix res…

### DIFF
--- a/malcolm/modules/ADPandABlocks/parts/pandaseqtriggerpart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandaseqtriggerpart.py
@@ -156,7 +156,8 @@ class PandASeqTriggerPart(builtin.parts.ChildPart):
         # Hooks
         registrar.hook(scanning.hooks.ReportStatusHook, self.report_status)
         registrar.hook((scanning.hooks.ConfigureHook,
-                        scanning.hooks.SeekHook), self.configure)
+                        scanning.hooks.SeekHook,
+                        scanning.hooks.PostRunArmedHook), self.configure)
         registrar.hook(scanning.hooks.RunHook, self.run)
 
     @add_call_types


### PR DESCRIPTION
…uming in 3D scans

This fixes the problem when an inner scan is paused and the remaining points in the current inner scan are used as the entirety of points in the inner scans that follow.