### PR TITLE
Fix/andor driver part exposure kwargs

### DIFF
--- a/malcolm/modules/ADAndor/parts/andordriverpart.py
+++ b/malcolm/modules/ADAndor/parts/andordriverpart.py
@@ -63,16 +63,33 @@ class AndorDriverPart(ADCore.parts.DetectorDriverPart):
             # and acquire period
             readout_time = child.acquirePeriod.value - child.exposure.value
             # Calculate the adjusted exposure time
-            (exposure, period) = self.get_adjusted_exposure_time_and_acquire_period(
-                duration, readout_time, kwargs.get("exposure", 0))
+            (exposure, period) = \
+                self.get_adjusted_exposure_time_and_acquire_period(
+                    duration,
+                    readout_time,
+                    kwargs.get("exposure", 0))
 
+        # The real exposure
         self.exposure.set_value(exposure)
         kwargs['exposure'] = exposure
+
         super(AndorDriverPart, self).setup_detector(
-            context, completed_steps, steps_to_do, duration, part_info, **kwargs)
+            context,
+            completed_steps,
+            steps_to_do,
+            duration,
+            part_info,
+            **kwargs)
+
         child.acquirePeriod.put_value(period)
 
-    def get_adjusted_exposure_time_and_acquire_period(self, duration, readout_time, exposure_time):
+    def get_adjusted_exposure_time_and_acquire_period(
+            self,
+            duration,  # type: float
+            readout_time,  # type: float
+            exposure_time  # type: float
+            ):
+        # type: (...) -> (float, float)
         # It seems that the difference between acquirePeriod and exposure
         # doesn't tell the whole story, we seem to need an additional bit
         # of readout (or something) time on top
@@ -87,4 +104,5 @@ class AndorDriverPart(ADCore.parts.DetectorDriverPart):
 
     @staticmethod
     def get_additional_readout_factor(duration):
+        # type: (float) -> float
         return duration * 0.004 + 0.001

--- a/malcolm/modules/ADAndor/parts/andordriverpart.py
+++ b/malcolm/modules/ADAndor/parts/andordriverpart.py
@@ -72,13 +72,11 @@ class AndorDriverPart(ADCore.parts.DetectorDriverPart):
             context, completed_steps, steps_to_do, duration, part_info, **kwargs)
         child.acquirePeriod.put_value(period)
 
-    @staticmethod
-    def get_adjusted_exposure_time_and_acquire_period(duration, readout_time, exposure_time):
+    def get_adjusted_exposure_time_and_acquire_period(self, duration, readout_time, exposure_time):
         # It seems that the difference between acquirePeriod and exposure
         # doesn't tell the whole story, we seem to need an additional bit
         # of readout (or something) time on top
-        fudge_factor = duration * 0.004 + 0.001
-        readout_time += fudge_factor
+        readout_time += self.get_additional_readout_factor(duration)
         # Otherwise we can behave like a "normal" detector
         info = scanning.infos.ExposureDeadtimeInfo(
             readout_time, frequency_accuracy=50, min_exposure=0.0)
@@ -86,3 +84,7 @@ class AndorDriverPart(ADCore.parts.DetectorDriverPart):
             duration, exposure_time)
         acquire_period = exposure_time + readout_time
         return exposure_time, acquire_period
+
+    @staticmethod
+    def get_additional_readout_factor(duration):
+        return duration * 0.004 + 0.001

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -63,7 +63,7 @@ class DetectorDriverPart(builtin.parts.ChildPart):
                        context,  # type: Context
                        completed_steps,  # type: scanning.hooks.ACompletedSteps
                        steps_to_do,  # type: scanning.hooks.AStepsToDo
-                       duration,  # type: int
+                       duration,  # type: float
                        part_info,  # type: scanning.hooks.APartInfo
                        **kwargs  # type: Any
                        ):

--- a/tests/test_modules/test_ADAndor/test_andordriverpart.py
+++ b/tests/test_modules/test_ADAndor/test_andordriverpart.py
@@ -1,10 +1,11 @@
 import pytest
-from mock import call
+from mock import call, Mock
 
 from scanpointgenerator import LineGenerator, CompoundGenerator
 from malcolm.core import Context, Process
 from malcolm.modules.ADAndor.parts import AndorDriverPart
 from malcolm.modules.ADAndor.blocks import andor_driver_block
+from malcolm.modules.ADCore.parts import DetectorDriverPart
 from malcolm.testutil import ChildTestCase
 
 
@@ -18,8 +19,8 @@ class TestAndorDetectorDriverPart(ChildTestCase):
             mri="mri", prefix="prefix")
         self.mock_when_value_matches(self.child)
         # readoutTime used to be 0.002, not any more...
-        self.o = AndorDriverPart(name="m", mri="mri")
-        self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
+        self.andor_driver_part = AndorDriverPart(name="m", mri="mri")
+        self.context.set_notify_dispatch_request(self.andor_driver_part.notify_dispatch_request)
         self.process.start()
 
     def tearDown(self):
@@ -33,7 +34,7 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         completed_steps = 0
         steps_to_do = 2000*3000
         file_dir = "/tmp"
-        self.o.on_configure(
+        self.andor_driver_part.on_configure(
             self.context, completed_steps, steps_to_do, {}, generator=generator,
             fileDir=file_dir)
 
@@ -59,7 +60,7 @@ class TestAndorDetectorDriverPart(ChildTestCase):
             call.put('acquirePeriod', 0.1 - 5e-6),
             call.post('start'),
             call.when_value_matches('acquiring', True, None)]
-        assert self.o.exposure.value == expected_exposure
+        assert self.andor_driver_part.exposure.value == expected_exposure
 
     def test_configure_frame_transfer(self):
         accumulate_period = 0.08
@@ -82,3 +83,136 @@ class TestAndorDetectorDriverPart(ChildTestCase):
             call.post('start'),
             call.when_value_matches('acquiring', True, None)]
 
+    def test_setup_detector_overwrites_exposure_in_kwargs_no_frame_transfer_mode(self):
+        # Mock our arguments
+        completed_steps = Mock(name="completed_steps_mock")
+        steps_to_do = Mock(name="steps_to_do_mock")
+        duration = 0.1
+        actual_exposure = 0.09
+        actual_period = 0.098
+        part_info = Mock(name="part_info")
+
+        # Mock the super setup_detector method
+        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
+        DetectorDriverPart.setup_detector = super_setup_detector_mock
+
+        # Mock the adjusted_exposure_time_and_acquire_period_method
+        adjusted_acquisition_mock = Mock(name="adjusted_acquisition_mock")
+        adjusted_acquisition_mock.return_value = (actual_exposure, actual_period)
+        self.andor_driver_part.get_adjusted_exposure_time_and_acquire_period = adjusted_acquisition_mock
+
+        self.andor_driver_part.setup_detector(
+            self.context, completed_steps, steps_to_do, duration, part_info, exposure=0.05)
+
+        # Check method calls
+        assert self.child.handled_requests.mock_calls == [
+            call.put('exposure', duration),
+            call.put('acquirePeriod', duration),
+            call.put('acquirePeriod', actual_period)
+        ]
+
+        super_setup_detector_mock.assert_called_once_with(
+            self.context, completed_steps, steps_to_do, duration, part_info, exposure=actual_exposure)
+
+        # Check exposure time
+        self.assertEqual(actual_exposure, self.andor_driver_part.exposure.value)
+
+    def test_setup_detector_adds_exposure_in_kwargs_no_frame_transfer_mode(self):
+        # Mock our arguments
+        completed_steps = Mock(name="completed_steps_mock")
+        steps_to_do = Mock(name="steps_to_do_mock")
+        duration = 1.0
+        actual_exposure = 0.99
+        actual_period = 0.95
+        part_info = Mock(name="part_info")
+
+        # Mock the super setup_detector method
+        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
+        DetectorDriverPart.setup_detector = super_setup_detector_mock
+
+        # Mock the adjusted_exposure_time_and_acquire_period_method
+        adjusted_acquisition_mock = Mock(name="adjusted_acquisition_mock")
+        adjusted_acquisition_mock.return_value = (actual_exposure, actual_period)
+        self.andor_driver_part.get_adjusted_exposure_time_and_acquire_period = adjusted_acquisition_mock
+
+        self.andor_driver_part.setup_detector(
+            self.context, completed_steps, steps_to_do, duration, part_info)
+
+        # Check method calls
+        assert self.child.handled_requests.mock_calls == [
+            call.put('exposure', duration),
+            call.put('acquirePeriod', duration),
+            call.put('acquirePeriod', actual_period)
+        ]
+
+        super_setup_detector_mock.assert_called_once_with(
+            self.context, completed_steps, steps_to_do, duration, part_info, exposure=actual_exposure)
+
+        # Check exposure time
+        self.assertEqual(actual_exposure, self.andor_driver_part.exposure.value)
+
+    def test_setup_detector_overwrites_exposure_in_kwargs_frame_transfer_mode(self):
+        # Mock our arguments
+        completed_steps = Mock(name="completed_steps_mock")
+        steps_to_do = Mock(name="steps_to_do_mock")
+        duration = 1.0
+        actual_exposure = 0.0
+        accumulate_period = 0.01
+        part_info = Mock(name="part_info")
+
+        # Mock the super setup_detector method
+        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
+        DetectorDriverPart.setup_detector = super_setup_detector_mock
+
+        # Turn on frame transfer mode and set accumulate period
+        self.set_attributes(
+            self.child, andorFrameTransferMode=True, andorAccumulatePeriod=accumulate_period)
+
+        self.andor_driver_part.setup_detector(
+            self.context, completed_steps, steps_to_do, duration, part_info, exposure=0.25)
+
+        # Check method calls
+        assert self.child.handled_requests.mock_calls == [
+            call.put('exposure', actual_exposure),
+            call.put('acquirePeriod', actual_exposure),
+            call.put('acquirePeriod', accumulate_period)
+        ]
+
+        super_setup_detector_mock.assert_called_once_with(
+            self.context, completed_steps, steps_to_do, duration, part_info, exposure=actual_exposure)
+
+        # Check exposure time
+        self.assertEqual(actual_exposure, self.andor_driver_part.exposure.value)
+
+    def test_setup_detector_adds_exposure_in_kwargs_frame_transfer_mode(self):
+        # Mock our arguments
+        completed_steps = Mock(name="completed_steps_mock")
+        steps_to_do = Mock(name="steps_to_do_mock")
+        duration = 1.0
+        actual_exposure = 0.0
+        accumulate_period = 0.01
+        part_info = Mock(name="part_info")
+
+        # Mock the super setup_detector method
+        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
+        DetectorDriverPart.setup_detector = super_setup_detector_mock
+
+        # Turn on frame transfer mode and set accumulate period
+        self.set_attributes(
+            self.child, andorFrameTransferMode=True, andorAccumulatePeriod=accumulate_period)
+
+        self.andor_driver_part.setup_detector(
+            self.context, completed_steps, steps_to_do, duration, part_info)
+
+        # Check method calls
+        assert self.child.handled_requests.mock_calls == [
+            call.put('exposure', actual_exposure),
+            call.put('acquirePeriod', actual_exposure),
+            call.put('acquirePeriod', accumulate_period)
+        ]
+
+        super_setup_detector_mock.assert_called_once_with(
+            self.context, completed_steps, steps_to_do, duration, part_info, exposure=actual_exposure)
+
+        # Check exposure time
+        self.assertEqual(actual_exposure, self.andor_driver_part.exposure.value)

--- a/tests/test_modules/test_ADAndor/test_andordriverpart.py
+++ b/tests/test_modules/test_ADAndor/test_andordriverpart.py
@@ -5,7 +5,6 @@ from scanpointgenerator import LineGenerator, CompoundGenerator
 from malcolm.core import Context, Process
 from malcolm.modules.ADAndor.parts import AndorDriverPart
 from malcolm.modules.ADAndor.blocks import andor_driver_block
-from malcolm.modules.ADCore.parts import DetectorDriverPart
 from malcolm.testutil import ChildTestCase
 
 

--- a/tests/test_modules/test_ADAndor/test_andordriverpart.py
+++ b/tests/test_modules/test_ADAndor/test_andordriverpart.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import call, Mock
+from mock import call, Mock, patch
 
 from scanpointgenerator import LineGenerator, CompoundGenerator
 from malcolm.core import Context, Process
@@ -83,7 +83,8 @@ class TestAndorDetectorDriverPart(ChildTestCase):
             call.post('start'),
             call.when_value_matches('acquiring', True, None)]
 
-    def test_setup_detector_overwrites_exposure_in_kwargs_no_frame_transfer_mode(self):
+    @patch("malcolm.modules.ADCore.parts.DetectorDriverPart.setup_detector")
+    def test_setup_detector_overwrites_exposure_in_kwargs_no_frame_transfer_mode(self, super_setup_detector_mock):
         # Mock our arguments
         completed_steps = Mock(name="completed_steps_mock")
         steps_to_do = Mock(name="steps_to_do_mock")
@@ -91,10 +92,6 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         actual_exposure = 0.09
         actual_period = 0.098
         part_info = Mock(name="part_info")
-
-        # Mock the super setup_detector method
-        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
-        DetectorDriverPart.setup_detector = super_setup_detector_mock
 
         # Mock the adjusted_exposure_time_and_acquire_period_method
         adjusted_acquisition_mock = Mock(name="adjusted_acquisition_mock")
@@ -117,7 +114,8 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         # Check exposure time
         self.assertEqual(actual_exposure, self.andor_driver_part.exposure.value)
 
-    def test_setup_detector_adds_exposure_in_kwargs_no_frame_transfer_mode(self):
+    @patch("malcolm.modules.ADCore.parts.DetectorDriverPart.setup_detector")
+    def test_setup_detector_adds_exposure_in_kwargs_no_frame_transfer_mode(self, super_setup_detector_mock):
         # Mock our arguments
         completed_steps = Mock(name="completed_steps_mock")
         steps_to_do = Mock(name="steps_to_do_mock")
@@ -125,10 +123,6 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         actual_exposure = 0.99
         actual_period = 0.95
         part_info = Mock(name="part_info")
-
-        # Mock the super setup_detector method
-        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
-        DetectorDriverPart.setup_detector = super_setup_detector_mock
 
         # Mock the adjusted_exposure_time_and_acquire_period_method
         adjusted_acquisition_mock = Mock(name="adjusted_acquisition_mock")
@@ -151,7 +145,8 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         # Check exposure time
         self.assertEqual(actual_exposure, self.andor_driver_part.exposure.value)
 
-    def test_setup_detector_overwrites_exposure_in_kwargs_frame_transfer_mode(self):
+    @patch("malcolm.modules.ADCore.parts.DetectorDriverPart.setup_detector")
+    def test_setup_detector_overwrites_exposure_in_kwargs_frame_transfer_mode(self, super_setup_detector_mock):
         # Mock our arguments
         completed_steps = Mock(name="completed_steps_mock")
         steps_to_do = Mock(name="steps_to_do_mock")
@@ -159,10 +154,6 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         actual_exposure = 0.0
         accumulate_period = 0.01
         part_info = Mock(name="part_info")
-
-        # Mock the super setup_detector method
-        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
-        DetectorDriverPart.setup_detector = super_setup_detector_mock
 
         # Turn on frame transfer mode and set accumulate period
         self.set_attributes(
@@ -184,7 +175,8 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         # Check exposure time
         self.assertEqual(actual_exposure, self.andor_driver_part.exposure.value)
 
-    def test_setup_detector_adds_exposure_in_kwargs_frame_transfer_mode(self):
+    @patch("malcolm.modules.ADCore.parts.DetectorDriverPart.setup_detector")
+    def test_setup_detector_adds_exposure_in_kwargs_frame_transfer_mode(self, super_setup_detector_mock):
         # Mock our arguments
         completed_steps = Mock(name="completed_steps_mock")
         steps_to_do = Mock(name="steps_to_do_mock")
@@ -192,10 +184,6 @@ class TestAndorDetectorDriverPart(ChildTestCase):
         actual_exposure = 0.0
         accumulate_period = 0.01
         part_info = Mock(name="part_info")
-
-        # Mock the super setup_detector method
-        super_setup_detector_mock = Mock(name='super_setup_detector_mock')
-        DetectorDriverPart.setup_detector = super_setup_detector_mock
 
         # Turn on frame transfer mode and set accumulate period
         self.set_attributes(


### PR DESCRIPTION
This fixes the issue with duplicate exposures in kwargs being passed from setup_detector in AndorDriverPart. I have also refactored the method and added some tests.
I also noticed the type hint for duration in DetectorDriverPart was int when I believe it should be a float.