### PR TITLE
Use newer BNL site for EPICS Base 3.15 (on Debian 8 Jessie)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: 'deb https://epics.nsls2.bnl.gov/debian/ wheezy main contrib'
-        key_url: 'https://epics.nsls2.bnl.gov/debian/repo-key.pub'
+      - sourceline: 'deb https://epicsdeb.bnl.gov/debian/ jessie main contrib'
+        key_url: 'https://epicsdeb.bnl.gov/debian/repo-key.pub'
     packages:
       - libhdf5-serial-dev
       - gdb


### PR DESCRIPTION
Build on Debian 7 Wheezy failed because the signature key for EPICS Base repository expired. The repository is a legacy one, so probably not maintained actively. There is a newer one at https://epicsdeb.bnl.gov/debian/ with Base 3.15 on Debian 8 Jessie.