### PR TITLE
ScanRunnerPart: fixed waiting for scan abort during run_scan()

### DIFF
--- a/malcolm/modules/scanning/parts/scanrunnerpart.py
+++ b/malcolm/modules/scanning/parts/scanrunnerpart.py
@@ -404,7 +404,7 @@ class ScanRunnerPart(builtin.parts.ChildPart):
 
         # Check if scan can be reset or run
         while self.scan_is_aborting(scan_block):
-            scan_block.sleep(0.1)
+            self.context.sleep(0.1)
 
         # Run the scan and capture the outcome
         if scan_block.state.value is not RunnableStates.READY:

--- a/tests/test_modules/test_scanning/test_scanrunnerpart.py
+++ b/tests/test_modules/test_scanning/test_scanrunnerpart.py
@@ -1467,6 +1467,10 @@ class TestScanRunnerPartRunScanMethod(unittest.TestCase):
         # Our mocked scan block will return nicely for a success
         self.scan_block_mock.run.return_value = None
 
+        # Mock our context
+        context_mock = Mock(name="context_mock")
+        self.scan_runner_part.context = context_mock
+
         # Mock the scan_is_aborting method
         is_aborting_mock = Mock(name="is_aborting_mock")
         is_aborting_mock.side_effect = [
@@ -1485,7 +1489,7 @@ class TestScanRunnerPartRunScanMethod(unittest.TestCase):
             self.generator_mock)
 
         # Check we slept
-        self.scan_block_mock.sleep.assert_called_once_with(0.1)
+        context_mock.sleep.assert_called_once_with(0.1)
 
         # Check the standard method calls
         self.create_and_get_scan_directory_mock.assert_called_once_with(self.set_directory, self.scan_number)


### PR DESCRIPTION
Fixed incorrect method call to sleep which is used to wait until a scan has finished aborting.