### PR TITLE
ADPilatus yaml name check pass

### DIFF
--- a/malcolm/modules/ADPilatus/blocks/__init__.py
+++ b/malcolm/modules/ADPilatus/blocks/__init__.py
@@ -1,8 +1,8 @@
 from malcolm.yamlutil import make_block_creator, check_yaml_names
 
-adpilatus_driver_block = make_block_creator(
-    __file__, " ADPilatus_driver_block.yaml")
-adpilatus_runnable_block = make_block_creator(
+ADPilatus_driver_block = make_block_creator(
+    __file__, "ADPilatus_driver_block.yaml")
+ADPilatus_runnable_block = make_block_creator(
     __file__, "ADPilatus_runnable_block.yaml")
 
 __all__ = check_yaml_names(globals())


### PR DESCRIPTION
I corrected the reasons why yaml checking of file names in ADPilatus fails