### PR TITLE
Calling abort on controller now makes run return in aborted state

### DIFF
--- a/malcolm/modules/scanning/controllers/runnablecontroller.py
+++ b/malcolm/modules/scanning/controllers/runnablecontroller.py
@@ -497,8 +497,8 @@ class RunnableController(builtin.controllers.ManagerController):
         will return in Fault state. If the user disables then it will return in
         Disabled state.
         """
-        # Tell _call_do_run not to resume
         self.try_aborting_function(ss.ABORTING, ss.ABORTED, self.do_abort)
+        # Tell _call_do_run not to resume
         if self.resume_queue:
             self.resume_queue.put(False)
 

--- a/malcolm/modules/scanning/controllers/runnablecontroller.py
+++ b/malcolm/modules/scanning/controllers/runnablecontroller.py
@@ -498,9 +498,9 @@ class RunnableController(builtin.controllers.ManagerController):
         Disabled state.
         """
         # Tell _call_do_run not to resume
+        self.try_aborting_function(ss.ABORTING, ss.ABORTED, self.do_abort)
         if self.resume_queue:
             self.resume_queue.put(False)
-        self.try_aborting_function(ss.ABORTING, ss.ABORTED, self.do_abort)
 
     def do_abort(self):
         # type: () -> None

--- a/tests/test_modules/test_scanning/test_runnablecontroller.py
+++ b/tests/test_modules/test_scanning/test_runnablecontroller.py
@@ -463,38 +463,6 @@ class TestRunnableController(unittest.TestCase):
         with self.assertRaises(AbortedError):
             f.result()
 
-
-class TestRunnableControllerAborting(unittest.TestCase):
-    def setUp(self):
-        self.p = Process('process')
-        self.context = Context(self.p)
-
-        # Make a motion block to act as our child
-        for c in motion_block(mri="childBlock", config_dir="/tmp"):
-            self.p.add_controller(c)
-        self.b_child = self.context.block_view("childBlock")
-
-        part = RunForeverPart(
-            mri='childBlock', name='part', initial_visibility=True)
-
-        # create a root block for the RunnableController block to reside in
-        self.c = RunnableController(mri='mainBlock', config_dir="/tmp")
-        self.c.add_part(part)
-        self.p.add_controller(self.c)
-        self.b = self.context.block_view("mainBlock")
-        self.ss = self.c.state_set
-
-        # start the process off
-        self.checkState(self.ss.DISABLED)
-        self.p.start()
-        self.checkState(self.ss.READY)
-
-    def tearDown(self):
-        self.p.stop(timeout=1)
-
-    def checkState(self, state):
-        self.assertEqual(self.c.state.value, state)
-
     def abort_after_1s(self):
         # Need a new context as in a different cothread
         c = Context(self.p)
@@ -505,6 +473,11 @@ class TestRunnableControllerAborting(unittest.TestCase):
         self.checkState(self.ss.ABORTED)
 
     def test_run_returns_in_ABORTED_state_when_aborted(self):
+        # Add our forever running part
+        forever_part = RunForeverPart(
+            mri='childBlock', name='forever_part', initial_visibility=True)
+        self.c.add_part(forever_part)
+
         # Configure our block
         duration = 0.1
         line1 = LineGenerator('y', 'mm', 0, 2, 3)

--- a/tests/test_modules/test_scanning/test_runnablecontroller.py
+++ b/tests/test_modules/test_scanning/test_runnablecontroller.py
@@ -123,23 +123,16 @@ class TestRunnableStates(unittest.TestCase):
 
 class TestRunnableController(unittest.TestCase):
     def setUp(self):
-        self.p = Process('process1')
+        self.p = Process('process')
         self.context = Context(self.p)
-
-        self.p2 = Process('process2')
-        self.context2 = Context(self.p2)
 
         # Make a motion block to act as our child
         for c in motion_block(mri="childBlock", config_dir="/tmp"):
             self.p.add_controller(c)
         self.b_child = self.context.block_view("childBlock")
 
-        # Make a RunnableChildPart to control the ticker_block
-        # part2 = RunnableChildPart(
-        #     mri='childBlock', name='part2', initial_visibility=True)
-
         part = MisbehavingPart(
-            mri='childBlock', name='part2', initial_visibility=True)
+            mri='childBlock', name='part', initial_visibility=True)
 
         # create a root block for the RunnableController block to reside in
         self.c = RunnableController(mri='mainBlock', config_dir="/tmp")
@@ -220,7 +213,7 @@ class TestRunnableController(unittest.TestCase):
         assert self.b.modified.alarm.severity == AlarmSeverity.MINOR_ALARM
         assert self.b.modified.alarm.status == AlarmStatus.CONF_STATUS
         assert self.b.modified.alarm.message == \
-            "part2.design.value = 'new_child' not 'init_child'"
+            "part.design.value = 'new_child' not 'init_child'"
         # Load the child again
         self.b_child.design.put_value("new_child")
         assert self.b.modified.value is True
@@ -282,7 +275,7 @@ class TestRunnableController(unittest.TestCase):
         self.b.run()
         self.checkState(self.ss.FINISHED)
 
-    def test_abort(self):
+    def test_abort_during_run(self):
         self.prepare_half_run()
         self.b.run()
         self.b.abort()

--- a/tests/test_modules/test_scanning/test_runnablecontroller.py
+++ b/tests/test_modules/test_scanning/test_runnablecontroller.py
@@ -67,9 +67,7 @@ class RunForeverPart(builtin.parts.ChildPart):
         super(RunForeverPart, self).setup(registrar)
         # Hooks
         registrar.hook(scanning.hooks.RunHook, self.on_run)
-        #registrar.hook(scanning.hooks.AbortHook, self.on_abort)
-        registrar.hook((scanning.hooks.AbortHook,
-                        scanning.hooks.PauseHook), self.on_abort)
+        registrar.hook(scanning.hooks.AbortHook, self.on_abort)
 
     @add_call_types
     def on_run(self, context):
@@ -475,7 +473,7 @@ class TestRunnableController(unittest.TestCase):
 
 class TestRunnableControllerAborting(unittest.TestCase):
     def setUp(self):
-        self.p = Process('process1')
+        self.p = Process('process')
         self.context = Context(self.p)
 
         # Make a motion block to act as our child
@@ -484,7 +482,7 @@ class TestRunnableControllerAborting(unittest.TestCase):
         self.b_child = self.context.block_view("childBlock")
 
         part = RunForeverPart(
-            mri='childBlock', name='part1', initial_visibility=True)
+            mri='childBlock', name='part', initial_visibility=True)
 
         # create a root block for the RunnableController block to reside in
         self.c = RunnableController(mri='mainBlock', config_dir="/tmp")
@@ -513,7 +511,7 @@ class TestRunnableControllerAborting(unittest.TestCase):
         b.abort()
         self.checkState(self.ss.ABORTED)
 
-    def test_run(self):
+    def test_run_returns_in_ABORTED_state_when_aborted(self):
         # Configure our block
         duration = 0.1
         line1 = LineGenerator('y', 'mm', 0, 2, 3)
@@ -532,4 +530,3 @@ class TestRunnableControllerAborting(unittest.TestCase):
 
         # Check the abort thread didn't raise
         abort_thread.Wait(1.0)
-


### PR DESCRIPTION
Controller now returns in ABORTED state from run after being aborted.

I have also fixed a duplicate test name and performed some renaming for clarity, as well as removing a couple of lines of unused code in the existing setup.