### PR TITLE
Improve PVA server logging

### DIFF
--- a/malcolm/core/process.py
+++ b/malcolm/core/process.py
@@ -216,7 +216,6 @@ class Process(Loggable):
         self._spawn_count = 0
         self._spawned = [s for s in self._spawned if not s.ready()]
 
-
     def add_controllers(self, controllers, timeout=None):
         # type: (List[Controller], float) -> None
         """Add many controllers to be hosted by this process

--- a/malcolm/imalcolm.py
+++ b/malcolm/imalcolm.py
@@ -202,7 +202,7 @@ def main():
 
     args = parse_args()
 
-    # Make some log config, either fron command line or
+    # Make some log config using command line args or defaults
     log_config = make_logging_config(args)
 
     # Start it off, and tell it to stop when we quit

--- a/malcolm/modules/pva/controllers/__init__.py
+++ b/malcolm/modules/pva/controllers/__init__.py
@@ -1,5 +1,6 @@
 from .pvaclientcomms import PvaClientComms
 from .pvaservercomms import PvaServerComms
+from .pvaservercomms import BlockHandler
 
 # Expose a nice namespace
 from malcolm.core import submodule_all

--- a/malcolm/modules/pva/controllers/pvaservercomms.py
+++ b/malcolm/modules/pva/controllers/pvaservercomms.py
@@ -71,9 +71,14 @@ class BlockHandler(Handler):
                 else:
                     ret = response.value
                 v = convert_dict_to_value(ret)
-                self.controller.log.debug(
-                    "%s: RPC method %s return value %s",
-                    self.controller.mri, method, ret)
+                if ret:
+                    self.controller.log.debug(
+                        "%s: RPC method %s returned with value %s",
+                        self.controller.mri, method, ret)
+                else:
+                    self.controller.log.debug(
+                        "%s: RPC method %s returned",
+                        self.controller.mri, method)
                 op.done(v)
             else:
                 if isinstance(response, Error):

--- a/malcolm/modules/pva/controllers/pvaservercomms.py
+++ b/malcolm/modules/pva/controllers/pvaservercomms.py
@@ -55,7 +55,7 @@ class BlockHandler(Handler):
         assert isinstance(view, Method), \
             "%s.%s is not a Method so cannot do RPC" % tuple(path)
         add_wrapper = method_return_unpacked() in view.meta.tags
-        
+
         self.controller.log.debug(
             "%s: RPC method %s called with params %s", self.controller.mri,
             method, parameters)
@@ -71,12 +71,21 @@ class BlockHandler(Handler):
                 else:
                     ret = response.value
                 v = convert_dict_to_value(ret)
+                self.controller.log.debug(
+                    "%s: RPC method %s return value %s",
+                    self.controller.mri, method, ret)
                 op.done(v)
             else:
                 if isinstance(response, Error):
                     message = stringify_error(response.message)
+                    self.controller.log.debug(
+                        "%s: RPC method %s resulted in an error (%s)",
+                        self.controller.mri, method, message)
                 else:
                     message = "BadResponse: %s" % response.to_dict()
+                    self.controller.log.debug(
+                        "%s: RPC method %s got a bad response (%s)",
+                        self.controller.mri, method, message)
                 op.done(error=message)
 
         post.set_callback(handle_post_response)

--- a/malcolm/modules/pva/controllers/pvaservercomms.py
+++ b/malcolm/modules/pva/controllers/pvaservercomms.py
@@ -55,7 +55,11 @@ class BlockHandler(Handler):
         assert isinstance(view, Method), \
             "%s.%s is not a Method so cannot do RPC" % tuple(path)
         add_wrapper = method_return_unpacked() in view.meta.tags
-
+        self.controller.log.debug(
+            "RPC method {method} called with params: {params}".format(
+                method=method,
+                params=parameters
+            ))
         post = Post(path=path, parameters=parameters)
 
         def handle_post_response(response):

--- a/malcolm/modules/pva/controllers/pvaservercomms.py
+++ b/malcolm/modules/pva/controllers/pvaservercomms.py
@@ -56,10 +56,8 @@ class BlockHandler(Handler):
             "%s.%s is not a Method so cannot do RPC" % tuple(path)
         add_wrapper = method_return_unpacked() in view.meta.tags
         self.controller.log.debug(
-            "RPC method {method} called with params: {params}".format(
-                method=method,
-                params=parameters
-            ))
+            "%s: RPC method %s called with params %s", self.controller.mri,
+            method, parameters)
         post = Post(path=path, parameters=parameters)
 
         def handle_post_response(response):

--- a/malcolm/modules/pva/controllers/pvaservercomms.py
+++ b/malcolm/modules/pva/controllers/pvaservercomms.py
@@ -55,6 +55,7 @@ class BlockHandler(Handler):
         assert isinstance(view, Method), \
             "%s.%s is not a Method so cannot do RPC" % tuple(path)
         add_wrapper = method_return_unpacked() in view.meta.tags
+        
         self.controller.log.debug(
             "%s: RPC method %s called with params %s", self.controller.mri,
             method, parameters)

--- a/tests/test_modules/test_pva/test_pvaservercomms.py
+++ b/tests/test_modules/test_pva/test_pvaservercomms.py
@@ -68,6 +68,47 @@ class TestBlockHandler(unittest.TestCase):
         )
         self.controller_mock.log.debug.assert_has_calls([rpc_call, response_call])
 
+    @patch('malcolm.modules.pva.controllers.pvaservercomms.Put')
+    @patch('malcolm.modules.pva.controllers.pvaservercomms.convert_value_to_dict')
+    def test_put_method_handle_put_response_nested_function_handles_BadResponse(
+            self, put_mock, convert_value_to_dict_mock):
+        pv_mock = MagicMock(name="pv_mock")
+        op_mock = MagicMock(name="op_mock")
+
+        # We need to mock value_changed
+        changed_fields_mock = MagicMock(name="changed_fields_mock")
+        value_mock = MagicMock(name="value_mock")
+        op_mock.value.return_value = value_mock
+        value_mock.changedSet.return_value = changed_fields_mock
+        changed_fields_mock.intersection.return_value = ["value"]
+
+        # Now the field can be set on the BlockHandler
+        self.block_handler.field = "field"
+
+        # Set up the mocked Post class to return a mocked instance
+        put_instance_mock = MagicMock(name="put_instance_mock")
+        put_mock.return_value = put_instance_mock
+
+        # Mock the callback method
+        response_mock = MagicMock(name="response_mock")
+        response_mock.to_dict.return_value = "this is a bad response indeed"
+
+        def mock_set_callback_func(*args):
+            args[0](response_mock)
+
+        put_instance_mock.set_callback.side_effect = mock_set_callback_func
+        put_mock.Put.set_callback.side_effect = mock_set_callback_func
+
+        # Now we can call the put method
+        self.block_handler.put(pv_mock, op_mock)
+
+        # Perform our checks
+        put_mock.assert_called_once()
+        put_instance_mock.set_callback.assert_called_once()
+
+        bad_response_message = "BadResponse: this is a bad response indeed"
+        op_mock.done.assert_called_once_with(error=bad_response_message)
+
 
 class TestPvaServerComms(unittest.TestCase):
 

--- a/tests/test_modules/test_pva/test_pvaservercomms.py
+++ b/tests/test_modules/test_pva/test_pvaservercomms.py
@@ -1,6 +1,8 @@
 import unittest
-from mock import MagicMock
+from mock import MagicMock, patch
+import sys
 
+import malcolm.modules.pva.controllers.pvaservercomms
 from malcolm.modules.pva.controllers import PvaServerComms
 
 
@@ -60,3 +62,18 @@ class TestPvaServerComms(unittest.TestCase):
 
         self.assertEqual("return_value", result)
         mock_make_channel.assert_called_once_with(channel_name, source)
+
+    @patch('malcolm.modules.pva.controllers.pvaservercomms.cothread.CallbackResult')
+    def test_makeChannel_calls_cothread_CallbackResult(self, callback_mock):
+        # Add channel
+        channel_name = "CHANNEL1"
+        source = "Source1"
+        self.pva_server_comms._published.add(channel_name)
+
+        self.pva_server_comms.makeChannel(channel_name, source)
+
+        callback_mock.assert_called_once_with(
+            self.pva_server_comms._make_channel,
+            channel_name,
+            source,
+            callback_timeout=1.0)

--- a/tests/test_modules/test_pva/test_pvaservercomms.py
+++ b/tests/test_modules/test_pva/test_pvaservercomms.py
@@ -1,4 +1,5 @@
 import unittest
+from mock import MagicMock
 
 from malcolm.modules.pva.controllers import PvaServerComms
 
@@ -44,3 +45,18 @@ class TestPvaServerComms(unittest.TestCase):
 
         self.assertRaises(
             NameError, self.pva_server_comms._make_channel, channel_name, source)
+
+    def test_makeChannel_returns_CallbackResult(self):
+        # Add channel
+        channel_name = "CHANNEL1"
+        source = "Source1"
+        self.pva_server_comms._published.add(channel_name)
+        # Mock make_channel method
+        mock_make_channel = MagicMock(name="mock_make_channel")
+        mock_make_channel.return_value = "return_value"
+        self.pva_server_comms._make_channel = mock_make_channel
+
+        result = self.pva_server_comms.makeChannel(channel_name, source)
+
+        self.assertEqual("return_value", result)
+        mock_make_channel.assert_called_once_with(channel_name, source)

--- a/tests/test_modules/test_pva/test_pvaservercomms.py
+++ b/tests/test_modules/test_pva/test_pvaservercomms.py
@@ -1,0 +1,46 @@
+import unittest
+
+from malcolm.modules.pva.controllers import PvaServerComms
+
+
+class TestPvaServerComms(unittest.TestCase):
+
+    def setUp(self):
+        self.pva_server_comms = PvaServerComms("TEST:COMMS")
+
+    def test_testChannel_returns_True_if_channel_is_in_published(self):
+        channel_name = "CHANNEL1"
+        self.pva_server_comms._published.add(channel_name)
+
+        self.assertEqual(True, self.pva_server_comms.testChannel(channel_name))
+
+    def test_testChannel_returns_True_if_channel_of_field_is_in_published(self):
+        channel_name = "CHANNEL1"
+        field = "FIELD1"
+        self.pva_server_comms._published.add(channel_name)
+
+        self.assertEqual(True, self.pva_server_comms.testChannel(
+            "{channel}.{field}".format(
+                channel=channel_name,
+                field=field)))
+
+    def test_testChannel_returns_False_if_channel_is_not_in_published(self):
+        channel_name = "CHANNEL1"
+
+        self.assertEqual(False, self.pva_server_comms.testChannel(channel_name))
+
+    def test_testChannel_returns_False_if_channel_of_field_is_not_in_published(self):
+        channel_name = "CHANNEL1"
+        field = "FIELD1"
+
+        self.assertEqual(False, self.pva_server_comms.testChannel(
+            "{channel}.{field}".format(
+                channel=channel_name,
+                field=field)))
+
+    def test_make_channel_raises_NameError_for_bad_channel_name(self):
+        channel_name = "CHANNEL1"
+        source = "Source1"
+
+        self.assertRaises(
+            NameError, self.pva_server_comms._make_channel, channel_name, source)


### PR DESCRIPTION
Just a small addition to re-add some logging for the PVA server comms when rpc() is called on BlockHandler.

What I wasn't sure about was whether I could get the logged parameters into a separate field on Graylog so it doesn't print the entire list in the main message.

I'm not sure if you want anything else logged here? This was sufficient to see the methods being called from GDA.