### PR TITLE
fix problem with sharksfin-like velocity time profile on high acceler…

### DIFF
--- a/malcolm/modules/pmac/infos.py
+++ b/malcolm/modules/pmac/infos.py
@@ -35,10 +35,12 @@ class MotorInfo(Info):
         ramp_time = abs(v2 - v1) / self.acceleration
         return ramp_time
 
-    def ramp_distance(self, v1, v2, ramp_time=None):
+    def ramp_distance(self, v1, v2, ramp_time=None, min_ramp_time=None):
         # The distance moved in the first part of the ramp
         if ramp_time is None:
             ramp_time = self.acceleration_time(v1, v2)
+        if min_ramp_time is not None:
+            ramp_time = max(ramp_time, min_ramp_time)
         ramp_distance = (v1 + v2) * ramp_time / 2
         return ramp_distance
 

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -483,7 +483,9 @@ class PmacChildPart(builtin.parts.ChildPart):
             for _ in range(nsplit):
                 self.profile["timeArray"].append(time_point / nsplit)
             for _ in range(nsplit - 1):
-                self.profile["velocityMode"].append(VelocityModes.AVERAGE_PREV_TO_NEXT)
+                self.profile["velocityMode"].append(
+                    VelocityModes.AVERAGE_PREV_TO_NEXT
+                )
                 self.profile["userPrograms"].append(UserPrograms.NO_PROGRAM)
             for k, v in axis_points.items():
                 cs_axis = self.axis_mapping[k].cs_axis.lower()
@@ -510,9 +512,11 @@ class PmacChildPart(builtin.parts.ChildPart):
     def add_generator_point_pair(self, point, point_num, points_are_joined):
         # Add position
         user_program = self.get_user_program(PointType.MID_POINT)
-        self.add_profile_point(point.duration / 2.0,
+        self.add_profile_point(
+            point.duration / 2.0,
             VelocityModes.AVERAGE_PREV_TO_NEXT, user_program, point_num,
-            {name: point.positions[name] for name in self.axis_mapping})
+            {name: point.positions[name] for name in self.axis_mapping}
+        )
 
         # insert the lower bound of the next frame
         if points_are_joined and not point.delay_after:

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -30,9 +30,9 @@ MAX_MOVE_TIME = 4.0
 
 # velocity modes
 class VelocityModes:
-    PREV_TO_NEXT = 0
-    PREV_TO_CURRENT = 1
-    CURRENT_TO_NEXT = 2
+    AVERAGE_PREV_TO_NEXT = 0
+    REAL_PREV_TO_CURRENT = 1
+    AVERAGE_PREV_TO_CURRENT = 2
     ZERO_VELOCITY = 3
 
 
@@ -429,7 +429,7 @@ class PmacChildPart(builtin.parts.ChildPart):
 
         self.profile["timeArray"] += time_intervals
         self.profile["velocityMode"] += \
-            [VelocityModes.PREV_TO_CURRENT] * num_intervals
+            [VelocityModes.REAL_PREV_TO_CURRENT] * num_intervals
         user_program = self.get_user_program(PointType.TURNAROUND)
         self.profile["userPrograms"] += [user_program] * num_intervals
         self.completed_steps_lookup += [completed_steps] * num_intervals
@@ -483,7 +483,7 @@ class PmacChildPart(builtin.parts.ChildPart):
             for _ in range(nsplit):
                 self.profile["timeArray"].append(time_point / nsplit)
             for _ in range(nsplit - 1):
-                self.profile["velocityMode"].append(VelocityModes.PREV_TO_NEXT)
+                self.profile["velocityMode"].append(VelocityModes.AVERAGE_PREV_TO_NEXT)
                 self.profile["userPrograms"].append(UserPrograms.NO_PROGRAM)
             for k, v in axis_points.items():
                 cs_axis = self.axis_mapping[k].cs_axis.lower()
@@ -511,16 +511,16 @@ class PmacChildPart(builtin.parts.ChildPart):
         # Add position
         user_program = self.get_user_program(PointType.MID_POINT)
         self.add_profile_point(point.duration / 2.0,
-            VelocityModes.PREV_TO_NEXT, user_program, point_num,
+            VelocityModes.AVERAGE_PREV_TO_NEXT, user_program, point_num,
             {name: point.positions[name] for name in self.axis_mapping})
 
         # insert the lower bound of the next frame
         if points_are_joined and not point.delay_after:
             user_program = self.get_user_program(PointType.POINT_JOIN)
-            velocity_point = VelocityModes.PREV_TO_NEXT
+            velocity_point = VelocityModes.AVERAGE_PREV_TO_NEXT
         else:
             user_program = self.get_user_program(PointType.END_OF_ROW)
-            velocity_point = VelocityModes.PREV_TO_CURRENT
+            velocity_point = VelocityModes.REAL_PREV_TO_CURRENT
 
         self.add_profile_point(
             point.duration / 2.0, velocity_point, user_program, point_num + 1,
@@ -565,7 +565,7 @@ class PmacChildPart(builtin.parts.ChildPart):
             user_program = self.get_user_program(PointType.MID_POINT)
             self.add_profile_point(
                 self.time_since_last_pvt + point.duration / 2.0,
-                VelocityModes.PREV_TO_NEXT, user_program, point_num,
+                VelocityModes.AVERAGE_PREV_TO_NEXT, user_program, point_num,
                 {name: point.positions[name] for name in self.axis_mapping})
             self.time_since_last_pvt = point.duration / 2.0
 
@@ -576,11 +576,18 @@ class PmacChildPart(builtin.parts.ChildPart):
             # this frame)
             if points_are_joined:
                 user_program = self.get_user_program(PointType.POINT_JOIN)
-                velocity_point = VelocityModes.PREV_TO_NEXT
+                velocity_point = VelocityModes.AVERAGE_PREV_TO_NEXT
             else:
                 point = points[point_num]
                 user_program = self.get_user_program(PointType.END_OF_ROW)
-                velocity_point = VelocityModes.PREV_TO_CURRENT
+                if self.time_since_last_pvt > 0:
+                    # if we have previously skipped points in this row then we
+                    # use AVERAGE_PREV_TO_CURRENT at the end of the row this breaks
+                    # the continuous line of REAL_PREV_TO_CURRENT which would
+                    # accumulate errors over the scan
+                    velocity_point = VelocityModes.AVERAGE_PREV_TO_CURRENT
+                else:
+                    velocity_point = VelocityModes.REAL_PREV_TO_CURRENT
 
             self.add_profile_point(
                 self.time_since_last_pvt, velocity_point,
@@ -624,7 +631,7 @@ class PmacChildPart(builtin.parts.ChildPart):
             # Add lower bound
             user_program = self.get_user_program(PointType.START_OF_ROW)
             self.add_profile_point(
-                run_up_time, VelocityModes.PREV_TO_CURRENT, user_program,
+                run_up_time, VelocityModes.REAL_PREV_TO_CURRENT, user_program,
                 start_index, axis_points)
 
         self.time_since_last_pvt = 0
@@ -721,6 +728,6 @@ class PmacChildPart(builtin.parts.ChildPart):
                 next_point.lower[axis_name]
 
         # Change the last point to be a live frame
-        self.profile["velocityMode"][-1] = VelocityModes.PREV_TO_CURRENT
+        self.profile["velocityMode"][-1] = VelocityModes.REAL_PREV_TO_CURRENT
         user_program = self.get_user_program(PointType.START_OF_ROW)
         self.profile["userPrograms"][-1] = user_program

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -184,7 +184,9 @@ class PmacChildPart(builtin.parts.ChildPart):
         for axis_name, velocity in point_velocities(
                 self.axis_mapping, first_point).items():
             motor_info = self.axis_mapping[axis_name]  # type: MotorInfo
-            acceleration_distance = motor_info.ramp_distance(0, velocity)
+            acceleration_distance = motor_info.ramp_distance(
+                0, velocity, min_ramp_time=MIN_TIME
+            )
             start_pos = first_point.lower[axis_name] - acceleration_distance
             args[motor_info.cs_axis.lower()] = start_pos
             # Time profile that the move is likely to take

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -242,7 +242,9 @@ class TestPMACChildPart(ChildTestCase):
                     100000, 3000000, 100000
                 ]),
                 userPrograms=pytest.approx(user_programs),
-                velocityMode=pytest.approx([1, 1, 1, 1, 1, 1, 1, 3])
+                # note the use of mode 2 AVERAGE_PREV_CURRENT at the end of each
+                # sparse linear row
+                velocityMode=pytest.approx([1, 2, 1, 1, 1, 1, 2, 3])
             )
         ]
         assert self.o.completed_steps_lookup == [0, 3, 3, 3, 3, 3, 6, 6]


### PR DESCRIPTION
…ation motors

I'm starting the pull request now so you can take a look, but I will also add a test that proves the result tomorrow.

The issue was that the start point position was calculated in pmac_child_part.move_to_start using motor_info.ramp_distance without any minimum ramp time.

However when calculating the run up time later in pmac_child_part.calculate_generator_profile we were capping at a minimum .002s. Thus the 1st Prev->Current velocity calculation was out and threw the rest of them.

This is probably my record for the longest, most circuitous route to a simple solution (and I was already world champion)