### PR TITLE
Fix/hdfwriterpart on windows

### DIFF
--- a/malcolm/modules/ADCore/infos.py
+++ b/malcolm/modules/ADCore/infos.py
@@ -28,13 +28,15 @@ class FilePathTranslatorInfo(Info):
         assert filepath.startswith(translator.path_prefix), \
             "filepath %s does not start with expected prefix %s" % (
                 filepath, translator.path_prefix)
+        assert filepath.find(":") == -1, \
+            "filepath %s has unexpected colon (incompatible on Windows)" % (
+                filepath)
 
-        filepath = filepath.replace(":", "_")
         if translator.network_prefix != "":
-             win_path = filepath.replace(
-                 translator.path_prefix,
-                 translator.network_prefix + translator.path_prefix
-                 ).replace("/", "\\")
+            win_path = filepath.replace(
+                translator.path_prefix,
+                translator.network_prefix + translator.path_prefix
+                ).replace("/", "\\")
         else:
             win_path = filepath.replace(
                 translator.path_prefix,

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -11,7 +11,7 @@ from malcolm.modules import builtin, scanning
 from ..infos import NDArrayDatasetInfo, NDAttributeDatasetInfo, \
     FilePathTranslatorInfo
 from ..util import ExtraAttributesTable, APartRunsOnWindows, DataType, \
-    SourceType, FRAME_TIMEOUT
+    SourceType, FRAME_TIMEOUT, XmlLayout
 
 with Anno("Is main detector dataset useful to publish in DatasetTable?"):
     AMainDatasetUseful = bool
@@ -254,8 +254,8 @@ class DetectorDriverPart(builtin.parts.ChildPart):
         # Tell detector to store NDAttributes if table given
         if len(self.extra_attributes.value.sourceId) > 0:
             attribute_xml = self.build_attribute_xml()
-            self.attributes_filename = os.path.join(
-                fileDir, "%s-attributes.xml" % self.mri)
+            self.attributes_filename = XmlLayout.get_layout_filename(
+                fileDir, self.mri)
             with open(self.attributes_filename, 'w') as xml:
                 xml.write(attribute_xml)
             assert hasattr(child, "attributesFile"), \

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -11,7 +11,7 @@ from malcolm.modules import builtin, scanning
 from ..infos import NDArrayDatasetInfo, NDAttributeDatasetInfo, \
     FilePathTranslatorInfo
 from ..util import ExtraAttributesTable, APartRunsOnWindows, DataType, \
-    SourceType, FRAME_TIMEOUT, XmlLayout
+    SourceType, FRAME_TIMEOUT, make_xml_filename
 
 with Anno("Is main detector dataset useful to publish in DatasetTable?"):
     AMainDatasetUseful = bool
@@ -254,8 +254,7 @@ class DetectorDriverPart(builtin.parts.ChildPart):
         # Tell detector to store NDAttributes if table given
         if len(self.extra_attributes.value.sourceId) > 0:
             attribute_xml = self.build_attribute_xml()
-            self.attributes_filename = XmlLayout.get_layout_filename(
-                fileDir, self.mri)
+            self.attributes_filename = make_xml_filename(fileDir, self.mri)
             with open(self.attributes_filename, 'w') as xml:
                 xml.write(attribute_xml)
             assert hasattr(child, "attributesFile"), \

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -11,7 +11,7 @@ from malcolm.core import APartName, Future, Info, Block, PartRegistrar, \
 from malcolm.modules import builtin, scanning
 from ..infos import CalculatedNDAttributeDatasetInfo, NDArrayDatasetInfo, \
     NDAttributeDatasetInfo, FilePathTranslatorInfo
-from ..util import APartRunsOnWindows, FRAME_TIMEOUT, XmlLayout
+from ..util import APartRunsOnWindows, FRAME_TIMEOUT, make_xml_filename
 
 if TYPE_CHECKING:
     from typing import Iterator, List, Dict
@@ -344,7 +344,7 @@ class HDFWriterPart(builtin.parts.ChildPart):
         futures += set_dimensions(child, generator)
         xml = make_layout_xml(generator, part_info,
                               self.write_all_nd_attributes.value)
-        self.layout_filename = XmlLayout.get_layout_filename(
+        self.layout_filename = make_xml_filename(
             file_dir, self.mri, suffix="layout")
         with open(self.layout_filename, "w") as f:
             f.write(xml)

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -346,14 +346,17 @@ class HDFWriterPart(builtin.parts.ChildPart):
                               self.write_all_nd_attributes.value)
         self.layout_filename = os.path.join(
             file_dir, "%s-layout.xml" % self.mri)
+        layout_filename_pv = self.layout_filename
+        if self.runs_on_windows:
+            # Filename for Windows IOC needs drive letter
+            layout_filename_pv = FilePathTranslatorInfo.translate_filepath(
+                part_info, self.layout_filename)
+            # We also need to adjust the Linux path to remove colons
+            self.layout_filename = self.layout_filename.replace(":", "_")
         with open(self.layout_filename, "w") as f:
             f.write(xml)
-        layout_filename = self.layout_filename
-        if self.runs_on_windows:
-            layout_filename = FilePathTranslatorInfo.translate_filepath(
-                part_info, self.layout_filename)
         futures += child.put_attribute_values_async(dict(
-            xmlLayout=layout_filename,
+            xmlLayout=layout_filename_pv,
             flushDataPerNFrames=steps_to_do,
             flushAttrPerNFrames=0))
         # Wait for the previous puts to finish

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -11,7 +11,7 @@ from malcolm.core import APartName, Future, Info, Block, PartRegistrar, \
 from malcolm.modules import builtin, scanning
 from ..infos import CalculatedNDAttributeDatasetInfo, NDArrayDatasetInfo, \
     NDAttributeDatasetInfo, FilePathTranslatorInfo
-from ..util import APartRunsOnWindows, FRAME_TIMEOUT
+from ..util import APartRunsOnWindows, FRAME_TIMEOUT, XmlLayout
 
 if TYPE_CHECKING:
     from typing import Iterator, List, Dict
@@ -344,19 +344,16 @@ class HDFWriterPart(builtin.parts.ChildPart):
         futures += set_dimensions(child, generator)
         xml = make_layout_xml(generator, part_info,
                               self.write_all_nd_attributes.value)
-        self.layout_filename = os.path.join(
-            file_dir, "%s-layout.xml" % self.mri)
-        layout_filename_pv = self.layout_filename
-        if self.runs_on_windows:
-            # Filename for Windows IOC needs drive letter
-            layout_filename_pv = FilePathTranslatorInfo.translate_filepath(
-                part_info, self.layout_filename)
-            # We also need to adjust the Linux path to remove colons
-            self.layout_filename = self.layout_filename.replace(":", "_")
+        self.layout_filename = XmlLayout.get_layout_filename(
+            file_dir, self.mri, suffix="layout")
         with open(self.layout_filename, "w") as f:
             f.write(xml)
+        layout_filename_pv_value = self.layout_filename
+        if self.runs_on_windows:
+            layout_filename_pv_value = FilePathTranslatorInfo.translate_filepath(
+                part_info, self.layout_filename)
         futures += child.put_attribute_values_async(dict(
-            xmlLayout=layout_filename_pv,
+            xmlLayout=layout_filename_pv_value,
             flushDataPerNFrames=steps_to_do,
             flushAttrPerNFrames=0))
         # Wait for the previous puts to finish

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -7,7 +7,7 @@ from malcolm.compat import et_to_string
 from malcolm.core import APartName, PartRegistrar
 from malcolm.modules import builtin, scanning
 from ..infos import CalculatedNDAttributeDatasetInfo, FilePathTranslatorInfo
-from ..util import StatisticsName, APartRunsOnWindows
+from ..util import StatisticsName, APartRunsOnWindows, XmlLayout
 
 with Anno("Which statistic to capture"):
     AStatsName = StatisticsName
@@ -78,8 +78,8 @@ class StatsPluginPart(builtin.parts.ChildPart):
             enableCallbacks=True,
             computeStatistics=True))
         xml = self._make_attributes_xml()
-        self.attributes_filename = os.path.join(
-            fileDir, "%s-attributes.xml" % self.mri)
+        self.attributes_filename = XmlLayout.get_layout_filename(
+            fileDir, self.mri)
         with open(self.attributes_filename, "w") as f:
             f.write(xml)
         attributes_filename = self.attributes_filename

--- a/malcolm/modules/ADCore/parts/statspluginpart.py
+++ b/malcolm/modules/ADCore/parts/statspluginpart.py
@@ -7,7 +7,7 @@ from malcolm.compat import et_to_string
 from malcolm.core import APartName, PartRegistrar
 from malcolm.modules import builtin, scanning
 from ..infos import CalculatedNDAttributeDatasetInfo, FilePathTranslatorInfo
-from ..util import StatisticsName, APartRunsOnWindows, XmlLayout
+from ..util import StatisticsName, APartRunsOnWindows, make_xml_filename
 
 with Anno("Which statistic to capture"):
     AStatsName = StatisticsName
@@ -78,8 +78,7 @@ class StatsPluginPart(builtin.parts.ChildPart):
             enableCallbacks=True,
             computeStatistics=True))
         xml = self._make_attributes_xml()
-        self.attributes_filename = XmlLayout.get_layout_filename(
-            fileDir, self.mri)
+        self.attributes_filename = make_xml_filename(fileDir, self.mri)
         with open(self.attributes_filename, "w") as f:
             f.write(xml)
         attributes_filename = self.attributes_filename

--- a/malcolm/modules/ADCore/util.py
+++ b/malcolm/modules/ADCore/util.py
@@ -1,3 +1,5 @@
+import os
+
 from annotypes import Anno, Array, Sequence, Union
 from enum import Enum
 
@@ -92,3 +94,11 @@ class ExtraAttributesTable(Table):
         self.sourceType = ASourceTypes(sourceType)
         self.dataType = ADataTypes(dataType)
         self.datasetType = AAttributeTypes(datasetType)
+
+
+class XmlLayout:
+
+    @staticmethod
+    def get_layout_filename(file_dir, mri, suffix="attributes"):
+        return os.path.join(
+            file_dir, "%s-%s.xml" % (mri.replace(":", "_"), suffix))

--- a/malcolm/modules/ADCore/util.py
+++ b/malcolm/modules/ADCore/util.py
@@ -96,9 +96,7 @@ class ExtraAttributesTable(Table):
         self.datasetType = AAttributeTypes(datasetType)
 
 
-class XmlLayout:
-
-    @staticmethod
-    def get_layout_filename(file_dir, mri, suffix="attributes"):
-        return os.path.join(
-            file_dir, "%s-%s.xml" % (mri.replace(":", "_"), suffix))
+def make_xml_filename(file_dir, mri, suffix="attributes"):
+    """Return a Block-specific filename for attribute or layout XML file"""
+    return os.path.join(
+        file_dir, "%s-%s.xml" % (mri.replace(":", "_"), suffix))

--- a/tests/test_modules/test_ADCore/test_detectordriverpart.py
+++ b/tests/test_modules/test_ADCore/test_detectordriverpart.py
@@ -126,6 +126,7 @@ class TestDetectorDriverPart(ChildTestCase):
             call.post('stop'),
             call.when_value_matches('acquiring', False, None)]
 
+
 class TestDetectorDriverPartWindows(ChildTestCase):
 
     def setUp(self):
@@ -134,7 +135,7 @@ class TestDetectorDriverPartWindows(ChildTestCase):
 
         def child_block():
             controllers, parts = adbase_parts(prefix="prefix")
-            controller = StatefulController("mri")
+            controller = StatefulController("WINDOWS:DETECTOR")
             for part in parts:
                 controller.add_part(part)
             return controllers + [controller]
@@ -142,7 +143,7 @@ class TestDetectorDriverPartWindows(ChildTestCase):
         self.child = self.create_child_block(child_block, self.process)
         self.mock_when_value_matches(self.child)
         self.o = DetectorDriverPart(
-            name="m", mri="mri", soft_trigger_modes=["Internal"],
+            name="m", mri="WINDOWS:DETECTOR", soft_trigger_modes=["Internal"],
             runs_on_windows=True)
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         self.process.start()
@@ -158,7 +159,7 @@ class TestDetectorDriverPartWindows(ChildTestCase):
         generator.prepare()
         completed_steps = 0
         steps_to_do = 6
-        expected_xml_filename = '\\\\dc\\tmp\\mri-attributes.xml'
+        expected_xml_filename = '\\\\dc\\tmp\\WINDOWS_DETECTOR-attributes.xml'
         self.set_attributes(self.child, triggerMode="Internal")
         extra_attributes = ExtraAttributesTable(
             name=["test1", "test2", "test3"],

--- a/tests/test_modules/test_ADCore/test_filepathtranslatorpart.py
+++ b/tests/test_modules/test_ADCore/test_filepathtranslatorpart.py
@@ -3,7 +3,6 @@ from mock import MagicMock, call
 from malcolm.core import PartRegistrar
 from malcolm.modules.ADCore.parts import FilepathTranslatorPart
 from malcolm.modules.ADCore.infos import FilePathTranslatorInfo
-#from annotypes import Anno, add_call_types
 
 
 class TestFilePathTranslatorPartLocal(unittest.TestCase):

--- a/tests/test_modules/test_ADCore/test_hdfwriterpart.py
+++ b/tests/test_modules/test_ADCore/test_hdfwriterpart.py
@@ -110,14 +110,14 @@ class TestHDFWriterPart(ChildTestCase):
         self.context = Context(self.process)
         self.child = self.create_child_block(
             hdf_writer_block, self.process,
-            mri="BLOCK-HDF5", prefix="prefix")
+            mri="BLOCK:HDF5", prefix="prefix")
         self.process.start()
 
     def tearDown(self):
         self.process.stop(2)
 
     def test_init(self):
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         c = RunnableController("mri", "/tmp")
         c.add_part(self.o)
@@ -210,11 +210,12 @@ class TestHDFWriterPart(ChildTestCase):
         assert infos[7].path == "/entry/detector/y_set"
         assert infos[7].uniqueid == ""
 
-        expected_xml_filename_local = "/tmp/BLOCK-HDF5-layout.xml"
         if on_windows:
-            expected_xml_filename_remote = "Y:\\BLOCK-HDF5-layout.xml"
+            expected_xml_filename_local = "/tmp/BLOCK_HDF5-layout.xml"
+            expected_xml_filename_remote = "Y:\\BLOCK_HDF5-layout.xml"
             expected_filepath = "Y:" + os.sep
         else:
+            expected_xml_filename_local = "/tmp/BLOCK:HDF5-layout.xml"
             expected_xml_filename_remote = expected_xml_filename_local
             expected_filepath = "/tmp" + os.sep
         # Wait for the start_future so the post gets through to our child
@@ -266,27 +267,27 @@ class TestHDFWriterPart(ChildTestCase):
 
     def test_configure(self):
         self.mock_when_value_matches(self.child)
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         actual_xml = self.configure_and_check_output()
         assert actual_xml.splitlines() == expected_xml.splitlines()
 
     def test_honours_write_all_attributes_flag(self):
         self.mock_when_value_matches(self.child)
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5", write_all_nd_attributes=False)
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5", write_all_nd_attributes=False)
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         actual_xml = self.configure_and_check_output()
         assert actual_xml.splitlines() == expected_xml_limited_attr.splitlines()
 
     def test_configure_windows(self):
         self.mock_when_value_matches(self.child)
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5", runs_on_windows=True)
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5", runs_on_windows=True)
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         actual_xml = self.configure_and_check_output(on_windows=True)
         assert actual_xml.splitlines() == expected_xml.splitlines()
 
     def test_run(self):
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         self.o.done_when_reaches = 38
         self.o.completed_offset = 0
@@ -304,7 +305,7 @@ class TestHDFWriterPart(ChildTestCase):
         assert self.o.registrar.report.call_args_list[0][0][0].steps == 38
 
     def test_run_and_flush(self):
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
 
         def set_unique_id():
             # Sleep for 2.5 seconds to ensure 2 flushes, and then set value to finish
@@ -332,7 +333,7 @@ class TestHDFWriterPart(ChildTestCase):
 
     def test_seek(self):
         self.mock_when_value_matches(self.child)
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         self.o.done_when_reaches = 10
         completed_steps = 4
@@ -345,7 +346,7 @@ class TestHDFWriterPart(ChildTestCase):
         assert self.o.done_when_reaches == 13
 
     def test_post_run_ready(self):
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         # Say that we've returned from start
         self.o.start_future = Future(None)
@@ -363,7 +364,7 @@ class TestHDFWriterPart(ChildTestCase):
 
     def test_post_run_ready_not_done_flush(self):
         # Say that we've returned from start
-        self.o = HDFWriterPart(name="m", mri="BLOCK-HDF5")
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
         self.o.start_future = Future(None)
         fname = "/tmp/test_filename"
         with open(fname, "w") as f:

--- a/tests/test_modules/test_ADCore/test_hdfwriterpart.py
+++ b/tests/test_modules/test_ADCore/test_hdfwriterpart.py
@@ -263,6 +263,8 @@ class TestHDFWriterPart(ChildTestCase):
         ]
         with open(expected_xml_filename_local) as f:
             actual_xml = f.read().replace(">", ">\n")
+        # Check the layout filename Malcolm uses for file creation
+        assert self.o.layout_filename == expected_xml_filename_local
         return actual_xml
 
     def test_configure(self):

--- a/tests/test_modules/test_ADCore/test_hdfwriterpart.py
+++ b/tests/test_modules/test_ADCore/test_hdfwriterpart.py
@@ -210,12 +210,11 @@ class TestHDFWriterPart(ChildTestCase):
         assert infos[7].path == "/entry/detector/y_set"
         assert infos[7].uniqueid == ""
 
+        expected_xml_filename_local = "/tmp/BLOCK_HDF5-layout.xml"
         if on_windows:
-            expected_xml_filename_local = "/tmp/BLOCK_HDF5-layout.xml"
             expected_xml_filename_remote = "Y:\\BLOCK_HDF5-layout.xml"
             expected_filepath = "Y:" + os.sep
         else:
-            expected_xml_filename_local = "/tmp/BLOCK:HDF5-layout.xml"
             expected_xml_filename_remote = expected_xml_filename_local
             expected_filepath = "/tmp" + os.sep
         # Wait for the start_future so the post gets through to our child

--- a/tests/test_modules/test_ADCore/test_infos.py
+++ b/tests/test_modules/test_ADCore/test_infos.py
@@ -1,6 +1,6 @@
 import unittest
 
-from malcolm.modules.ADCore.infos import FilePathTranslatorInfo
+from malcolm.modules.ADCore.infos import FilePathTranslatorInfo, NDAttributeDatasetInfo
 
 
 class TestInfo(unittest.TestCase):
@@ -34,3 +34,9 @@ class TestInfo(unittest.TestCase):
 
         self.assertRaises(AssertionError, info.translate_filepath, part_info, filepath)
 
+
+class TestNDAttributeDatasetInfo(unittest.TestCase):
+
+    def test_from_attribute_type_raises_AttributeError_with_bad_dataset_type(self):
+
+        self.assertRaises(AttributeError, NDAttributeDatasetInfo.from_attribute_type, "POSITION", float, "POSITION.X")

--- a/tests/test_modules/test_ADCore/test_infos.py
+++ b/tests/test_modules/test_ADCore/test_infos.py
@@ -5,23 +5,32 @@ from malcolm.modules.ADCore.infos import FilePathTranslatorInfo
 
 class TestInfo(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    def test_file_path_translator_drive_mount(self):
+    def test_file_path_translator_drive_mount_succeeds_with_valid_path(self):
         info = FilePathTranslatorInfo("C", "/foo", "")
         part_info = {"WINPATH": [info]}
-        win_path = info.translate_filepath(part_info, 
-            "/foo/directory/file:name.xml")
+        win_path = info.translate_filepath(
+            part_info, "/foo/directory/file_name.xml")
 
         assert "C:\\directory\\file_name.xml" == win_path
 
-    def test_file_path_translator_network_mount(self):
+    def test_file_path_translator_network_mount_succeeds_with_valid_path(self):
         info = FilePathTranslatorInfo("", "/foo", "//dc")
         part_info = {"WINPATH": [info]}
         win_path = info.translate_filepath(part_info, "/foo/directory")
 
         assert "\\\\dc\\foo\\directory" == win_path
+
+    def test_file_path_translator_raises_AssertionError_with_bad_filepath_prefix(self):
+        info = FilePathTranslatorInfo("C", "/foo", "")
+        part_info = {"WINPATH": [info]}
+        filepath = "foo/directory"
+
+        self.assertRaises(AssertionError, info.translate_filepath, part_info, filepath)
+
+    def test_file_path_translator_raises_AssertionError_with_colon_in_filepath(self):
+        info = FilePathTranslatorInfo("C", "/foo", "")
+        part_info = {"WINPATH": [info]}
+        filepath = "/foo/directory/bad:filename"
+
+        self.assertRaises(AssertionError, info.translate_filepath, part_info, filepath)
+

--- a/tests/test_modules/test_ADCore/test_statspluginpart.py
+++ b/tests/test_modules/test_ADCore/test_statspluginpart.py
@@ -14,13 +14,13 @@ class TestStatsPluginPart(ChildTestCase):
         self.context = Context(self.process)
         self.child = self.create_child_block(
             stats_plugin_block, self.process,
-            mri="BLOCK-STAT", prefix="prefix")
+            mri="BLOCK:STAT", prefix="prefix")
 
     def tearDown(self):
         self.process.stop(timeout=2)
 
     def test_report_info(self):
-        self.o = StatsPluginPart(name="m", mri="BLOCK-STAT")
+        self.o = StatsPluginPart(name="m", mri="BLOCK:STAT")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         self.process.start()
         assert list(sorted(self.o.no_save_attribute_names)) == [
@@ -32,14 +32,14 @@ class TestStatsPluginPart(ChildTestCase):
         assert infos[0].attr == "STATS_TOTAL"
 
     def test_configure(self):
-        self.o = StatsPluginPart(name="m", mri="BLOCK-STAT")
+        self.o = StatsPluginPart(name="m", mri="BLOCK:STAT")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         self.process.start()
         fileDir = "/tmp"
         part_info = {}
         infos = self.o.on_configure(self.context, part_info, fileDir)
         assert infos is None
-        expected_filename = "/tmp/BLOCK-STAT-attributes.xml"
+        expected_filename = "/tmp/BLOCK_STAT-attributes.xml"
         assert self.child.handled_requests.mock_calls == [
             call.put('computeStatistics', True),
             call.put('enableCallbacks', True),
@@ -53,15 +53,15 @@ class TestStatsPluginPart(ChildTestCase):
         assert actual_xml.splitlines() == expected_xml.splitlines()
 
     def test_configure_windows(self):
-        self.o = StatsPluginPart(name="m", mri="BLOCK-STAT", runs_on_windows=True)
+        self.o = StatsPluginPart(name="m", mri="BLOCK:STAT", runs_on_windows=True)
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
         self.process.start()
         fileDir = "/tmp"
         part_info = {"sth": [FilePathTranslatorInfo("X", "/tmp", "")]}
         infos = self.o.on_configure(self.context, part_info, fileDir)
         assert infos is None
-        expected_filename_unix = "/tmp/BLOCK-STAT-attributes.xml"
-        expected_filename_windows = "X:\\BLOCK-STAT-attributes.xml"
+        expected_filename_unix = "/tmp/BLOCK_STAT-attributes.xml"
+        expected_filename_windows = "X:\\BLOCK_STAT-attributes.xml"
         assert self.child.handled_requests.mock_calls == [
             call.put('computeStatistics', True),
             call.put('enableCallbacks', True),

--- a/tests/test_modules/test_ADCore/test_util.py
+++ b/tests/test_modules/test_ADCore/test_util.py
@@ -1,0 +1,34 @@
+import unittest
+
+from malcolm.modules.ADCore.util import XmlLayout
+
+
+class TestXmlLayout(unittest.TestCase):
+
+    def test_get_layout_filename_returns_path_for_default_suffix(self):
+        file_dir = "/file/dir"
+        mri = "TEST_MRI"
+
+        expected_filename = "/file/dir/TEST_MRI-attributes.xml"
+        actual_filename = XmlLayout.get_layout_filename(file_dir, mri)
+
+        self.assertEqual(expected_filename, actual_filename)
+
+    def test_get_layout_filename_returns_path_for_custom_suffix(self):
+        file_dir = "/file/dir"
+        mri = "TEST_MRI"
+        suffix = "layout"
+
+        expected_filename = "/file/dir/TEST_MRI-layout.xml"
+        actual_filename = XmlLayout.get_layout_filename(file_dir, mri, suffix=suffix)
+
+        self.assertEqual(expected_filename, actual_filename)
+
+    def test_get_layout_filename_converts_colons_in_mri_to_underscore(self):
+        file_dir = "/file/dir"
+        mri = "TEST:MRI:NAME"
+
+        expected_filename = "/file/dir/TEST_MRI_NAME-attributes.xml"
+        actual_filename = XmlLayout.get_layout_filename(file_dir, mri)
+
+        self.assertEqual(expected_filename, actual_filename)

--- a/tests/test_modules/test_ADCore/test_util.py
+++ b/tests/test_modules/test_ADCore/test_util.py
@@ -1,34 +1,34 @@
 import unittest
 
-from malcolm.modules.ADCore.util import XmlLayout
+from malcolm.modules.ADCore.util import make_xml_filename
 
 
-class TestXmlLayout(unittest.TestCase):
+class TestMakeXmlFilename(unittest.TestCase):
 
-    def test_get_layout_filename_returns_path_for_default_suffix(self):
+    def test_make_xml_filename_returns_path_for_default_suffix(self):
         file_dir = "/file/dir"
         mri = "TEST_MRI"
 
         expected_filename = "/file/dir/TEST_MRI-attributes.xml"
-        actual_filename = XmlLayout.get_layout_filename(file_dir, mri)
+        actual_filename = make_xml_filename(file_dir, mri)
 
         self.assertEqual(expected_filename, actual_filename)
 
-    def test_get_layout_filename_returns_path_for_custom_suffix(self):
+    def test_make_xml_filename_returns_path_for_custom_suffix(self):
         file_dir = "/file/dir"
         mri = "TEST_MRI"
         suffix = "layout"
 
         expected_filename = "/file/dir/TEST_MRI-layout.xml"
-        actual_filename = XmlLayout.get_layout_filename(file_dir, mri, suffix=suffix)
+        actual_filename = make_xml_filename(file_dir, mri, suffix=suffix)
 
         self.assertEqual(expected_filename, actual_filename)
 
-    def test_get_layout_filename_converts_colons_in_mri_to_underscore(self):
+    def test_make_xml_filename_converts_colons_in_mri_to_underscore(self):
         file_dir = "/file/dir"
         mri = "TEST:MRI:NAME"
 
         expected_filename = "/file/dir/TEST_MRI_NAME-attributes.xml"
-        actual_filename = XmlLayout.get_layout_filename(file_dir, mri)
+        actual_filename = make_xml_filename(file_dir, mri)
 
         self.assertEqual(expected_filename, actual_filename)


### PR DESCRIPTION
This fixes the problem for Windows IOCs where Malcolm still creates the XML layout file with colons in the filename even though <HDF_PLUGIN>:XMLFileName will be appropriately converted to use underscores (in addition to the Windows drive letter).

- I have renamed the value of the layout file that is put to the PV over Channel Access
- The XML layout file is now created after the run on Windows check
- I have updated the MRI names used in the HDFWriterPart tests to use colons as would be typical for a real Beamline, and added a check in the configure test to ensure the colon is converted for Windows IOCs
