### PR TITLE
HDFWriterPart now checks XML layout file is valid during configure

### DIFF
--- a/malcolm/modules/ADCore/blocks/hdf_writer_block.yaml
+++ b/malcolm/modules/ADCore/blocks/hdf_writer_block.yaml
@@ -87,6 +87,16 @@
     pv: $(prefix):XMLFileName
     rbv_suffix: _RBV
 
+- ca.parts.CABooleanPart:
+    name: xmlLayoutValid
+    description: Reports XML layout validity
+    rbv: $(prefix):XMLValid_RBV
+
+- ca.parts.CACharArrayPart:
+    name: xmlErrorMsg
+    description: XML layout error message
+    rbv: $(prefix):XMLErrorMsg_RBV
+
 # Filename
 - ca.parts.CACharArrayPart:
     name: filePath

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -365,10 +365,15 @@ class HDFWriterPart(builtin.parts.ChildPart):
         # Start a future waiting for the first array
         self.array_future = child.when_value_matches_async(
             "arrayCounterReadback", greater_than_zero)
+        self._check_xml_is_valid(child)
         # Return the dataset information
         dataset_infos = list(create_dataset_infos(
             formatName, part_info, generator, filename))
         return dataset_infos
+
+    def _check_xml_is_valid(self, child):
+        assert child.xmlLayoutValid.value, \
+            "%s: invalid XML layout file (%s)" % (self.mri, child.xmlErrorMsg.value)
 
     @add_call_types
     def on_seek(self,


### PR DESCRIPTION
Added a check in configure to assert <HDF5>:XMLValid_RBV or otherwise report the status message.

If this check is not in place then any invalid XML layout file (path or formatting) will stop the images from being written and the scan will still succeed even though there is no data.