### PR TITLE
Fix hang when calling unsubscribe in callback

### DIFF
--- a/malcolm/core/context.py
+++ b/malcolm/core/context.py
@@ -433,6 +433,13 @@ class Context(object):
             if response.id in self._subscriptions:
                 func, args = self._subscriptions[response.id]
                 func(response.value, *args)
+            # func() may call wait_for_futures() which may call set_result on
+            # some futures that aren't known to it. This means that some of
+            # our futures list are now concluded, so filter them out. If we
+            # didn't do this we would hang forever
+            for future in futures:
+                if future not in self._requests:
+                    futures.remove(future)
         elif isinstance(response, Return):
             future = self._futures.pop(response.id)
             del self._requests[future]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
 
 tests_require = [
     'mock>=2.0.0', 'nose>=1.3.0', 'coverage>=3.7.1', 'pytest>=3.10.1',
-    'pytest-cov>=2.6.1']
+    'pytest-cov>=2.6.1', 'pytest-timeout>=1.4.1']
 
 # Place the directory containing _version_git on the path
 for path, _, filenames in os.walk(os.path.dirname(os.path.abspath(__file__))):


### PR DESCRIPTION
This change uses the pytest-timeout module to limit the duration of the test, as if it fails it will hang indefinitely.