### PR TITLE
make ADTetrAMM consider point duration and a exposure dead time

### DIFF
--- a/malcolm/modules/ADTetrAMM/blocks/tetrAMM_driver_block.yaml
+++ b/malcolm/modules/ADTetrAMM/blocks/tetrAMM_driver_block.yaml
@@ -35,3 +35,21 @@
     pv: $(pv_prefix):TriggerMode
     rbv_suffix: _RBV
 
+- ca.parts.CADoublePart:
+    name: exposure
+    description: Exposure time for each frame
+    pv: $(pv_prefix):AveragingTime
+    rbv_suffix: _RBV
+
+- builtin.parts.Float64Part:
+    name: acquirePeriod
+    description: Duration of each frame including readout
+    writeable: True
+    precision: 6
+    units: s
+
+- ca.parts.CALongPart:
+    name: valuesPerRead
+    description: Number of samples in which the averaging is computed
+    pv: $(pv_prefix):ValuesPerRead
+    rbv_suffix: _RBV

--- a/malcolm/modules/ADTetrAMM/blocks/tetrAMM_runnable_block.yaml
+++ b/malcolm/modules/ADTetrAMM/blocks/tetrAMM_runnable_block.yaml
@@ -22,7 +22,10 @@
     name: TetrAMM
     mri: $(mri_prefix):DRV
 
+- scanning.parts.ExposureDeadtimePart:
+    name: DEADTIME
+    initial_readout_time: 1e-3
+
 - ADCore.includes.filewriting_collection:
     pv_prefix: $(pv_prefix)
     mri_prefix: $(mri_prefix)
-

--- a/malcolm/modules/ADTetrAMM/parts/tetrammdriverpart.py
+++ b/malcolm/modules/ADTetrAMM/parts/tetrammdriverpart.py
@@ -1,15 +1,47 @@
+from math import ceil
+
 from annotypes import add_call_types
 
-from malcolm.core import PartRegistrar
+from malcolm.core import NumberMeta, PartRegistrar, Widget
 from malcolm.modules import ADCore, builtin, scanning
 
+APartName = builtin.parts.APartName
+AMri = builtin.parts.AMri
+TETRAMM_BASE_FREQ = 100000.0
+TETRAMM_MIN_VALUES_PER_READ = 5
 
-@builtin.util.no_save("numImagesPerSeries")
+
+@builtin.util.no_save("numImagesPerSeries", "valuesPerRead")
 class TetrAMMDriverPart(ADCore.parts.DetectorDriverPart):
+    def __init__(self, name: APartName, mri: AMri) -> None:
+        super().__init__(name, mri)
+        self.targetSamplesPerFrame = NumberMeta(
+            "uint32",
+            "Target samples that each frame contains, "
+            "0 for maximum, -1 for not controlling it.",
+            tags=[Widget.TEXTINPUT.tag()],
+        ).create_attribute_model()
+
     def setup(self, registrar: PartRegistrar) -> None:
         super().setup(registrar)
+        registrar.add_attribute_model("targetSamplesPerFrame",
+                                      self.targetSamplesPerFrame,
+                                      self.targetSamplesPerFrame.set_value)
         registrar.hook(scanning.hooks.PostRunReadyHook, self.on_post_run_ready)
         registrar.hook(scanning.hooks.PostRunArmedHook, self.on_post_run_armed)
+        registrar.hook(scanning.hooks.PostConfigureHook,
+                       self.on_post_configure)
+
+    @add_call_types
+    def on_post_configure(self, context: scanning.hooks.AContext):
+        child = context.block_view(self.mri)
+        if self.targetSamplesPerFrame.value == 0:
+            child.valuesPerRead.put_value(TETRAMM_MIN_VALUES_PER_READ)
+        elif self.targetSamplesPerFrame.value > 0:
+            values_per_read = ceil(TETRAMM_BASE_FREQ * child.exposure.value
+                                   / self.targetSamplesPerFrame.value)
+            values_per_read = max(values_per_read, TETRAMM_MIN_VALUES_PER_READ)
+            child.valuesPerRead.put_value(values_per_read)
 
     @add_call_types
     def on_run(self, context: scanning.hooks.AContext) -> None:


### PR DESCRIPTION
This change resolves [jira issue I22-1027](https://jira.diamond.ac.uk/browse/I22-1027).
As tetrAMM AD driver is not a standard one (it misses a few expected PVs), the following tricks were used:
- exposure attribute is using the averaging time PV, which is a good approximation, as it is the time in which the device will be taking samples
- The acquire period was added as a Float64Part in order to bypass the error in which the parent class (DetectorDriverPart) tries to set it.
Another approach could be modifying the DetectorDriverPart class, but because the tratrAMM is probably the only exception needing it, I thought it was better to have a 'dummy' part and keep the code as it is.

I've marked this PR as WIP because it hasn't been tested for python3 Pymalcolm, but it will be done next shutdown.