### PR TITLE
Feature/directory monitor

### DIFF
--- a/malcolm/modules/ADPandABlocks/parts/pandaseqtriggerpart.py
+++ b/malcolm/modules/ADPandABlocks/parts/pandaseqtriggerpart.py
@@ -1,3 +1,4 @@
+from operator import itemgetter
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -128,7 +129,7 @@ def _what_moves_most(
     )
 
     # Sort on abs(diff), take the biggest
-    axis_name = sorted(diffs, key=diffs.get)[-1]
+    axis_name = max(diffs.items(), key=itemgetter(1))[0]
     compare_cts, increasing = compare_increasing[axis_name]
     return axis_name, compare_cts, increasing
 

--- a/malcolm/modules/scanning/blocks/__init__.py
+++ b/malcolm/modules/scanning/blocks/__init__.py
@@ -3,5 +3,6 @@ from malcolm.yamlutil import check_yaml_names, make_block_creator
 shutter_block = make_block_creator(__file__, "shutter_block.yaml")
 scan_runner_block = make_block_creator(__file__, "scan_runner_block.yaml")
 attribute_block = make_block_creator(__file__, "attribute_block.yaml")
+directory_monitor_block = make_block_creator(__file__, "directory_monitor_block.yaml")
 
 __all__ = check_yaml_names(globals())

--- a/malcolm/modules/scanning/blocks/directory_monitor_block.yaml
+++ b/malcolm/modules/scanning/blocks/directory_monitor_block.yaml
@@ -14,6 +14,8 @@
     name: managerCheck
     description: Run the directory check
     pv: $(manager_pv):POLL.PROC
+    status_pv: $(manager_pv):ALL_VALID
+    good_status: Yes
 
 - ca.parts.CABooleanPart:
     name: managerStatus

--- a/malcolm/modules/scanning/blocks/directory_monitor_block.yaml
+++ b/malcolm/modules/scanning/blocks/directory_monitor_block.yaml
@@ -1,0 +1,26 @@
+- builtin.parameters.string:
+    name: manager_pv
+    description: PV root for the directoryMonitor Manager
+
+- builtin.parameters.string:
+    name: mri
+    description: MRI of the controller
+
+- builtin.controllers.StatefulController:
+    mri: $(mri)
+    description: Controller for checking directory monitor
+
+- ca.parts.CAActionPart:
+    name: managerCheck
+    description: Run the directory check
+    pv: $(manager_pv):POLL.PROC
+
+- ca.parts.CABooleanPart:
+    name: managerStatus
+    description: Directory status
+    rbv: $(manager_pv):ALL_VALID
+
+- ca.parts.CAStringPart:
+    name: managerHostname
+    description: Server hostname
+    rbv: $(manager_pv):HOSTNAME

--- a/malcolm/modules/scanning/parts/__init__.py
+++ b/malcolm/modules/scanning/parts/__init__.py
@@ -4,6 +4,7 @@ from malcolm.core import submodule_all
 from .attributeprerunpart import AttributePreRunPart
 from .datasettablepart import DatasetTablePart
 from .detectorchildpart import AInitialVisibility, AMri, APartName, DetectorChildPart
+from .directorymonitorpart import DirectoryMonitorPart
 from .exposuredeadtimepart import (
     AInitialAccuracy,
     AInitialReadoutTime,

--- a/malcolm/modules/scanning/parts/directorymonitorpart.py
+++ b/malcolm/modules/scanning/parts/directorymonitorpart.py
@@ -1,0 +1,42 @@
+from annotypes import Anno, add_call_types
+
+from malcolm.core import PartRegistrar
+from malcolm.modules.builtin.hooks import AContext
+from malcolm.modules.builtin.parts import AMri, APartName, ChildPart
+
+from .. import hooks
+
+with Anno("Whether to raise a ValueError for a bad status"):
+    AErrorOnFail = bool
+
+
+class DirectoryMonitorPart(ChildPart):
+    """Part for checking a directoryMonitor Manager is happy"""
+
+    def __init__(
+        self, name: APartName, mri: AMri, error_on_fail: AErrorOnFail = True
+    ) -> None:
+        super().__init__(name, mri, initial_visibility=True)
+        self.error_on_fail = error_on_fail
+
+    def setup(self, registrar: PartRegistrar) -> None:
+        super().setup(registrar)
+        # Hooks
+        registrar.hook(hooks.ConfigureHook, self.check_directories)
+
+    @add_call_types
+    def check_directories(self, context: AContext) -> None:
+        child = context.block_view(self.mri)
+        # Perform check
+        getattr(child, "managerCheck")()
+
+        # Get status
+        status = getattr(child, "managerStatus").value
+        if not status:
+            hostname = getattr(child, "managerHostname").value
+            bad_status_string = (
+                f"{self.mri}: bad directory monitor status for server {hostname}"
+            )
+            self.log.error(bad_status_string)
+            if self.error_on_fail:
+                raise ValueError(bad_status_string)

--- a/malcolm/modules/scanning/parts/directorymonitorpart.py
+++ b/malcolm/modules/scanning/parts/directorymonitorpart.py
@@ -27,13 +27,11 @@ class DirectoryMonitorPart(ChildPart):
     @add_call_types
     def check_directories(self, context: AContext) -> None:
         child = context.block_view(self.mri)
-        # Perform check
-        getattr(child, "managerCheck")()
+        child.managerCheck()
 
-        # Get status
-        status = getattr(child, "managerStatus").value
+        status = child.managerStatus.value
         if not status:
-            hostname = getattr(child, "managerHostname").value
+            hostname = child.managerHostname.value
             bad_status_string = (
                 f"{self.mri}: bad directory monitor status for server {hostname}"
             )

--- a/malcolm/modules/scanning/parts/directorymonitorpart.py
+++ b/malcolm/modules/scanning/parts/directorymonitorpart.py
@@ -27,10 +27,9 @@ class DirectoryMonitorPart(ChildPart):
     @add_call_types
     def check_directories(self, context: AContext) -> None:
         child = context.block_view(self.mri)
-        child.managerCheck()
-
-        status = child.managerStatus.value
-        if not status:
+        try:
+            child.managerCheck()
+        except AssertionError:
             hostname = child.managerHostname.value
             bad_status_string = (
                 f"{self.mri}: bad directory monitor status for server {hostname}"

--- a/tests/test_modules/test_scanning/test_attributeprerunpart.py
+++ b/tests/test_modules/test_scanning/test_attributeprerunpart.py
@@ -32,21 +32,21 @@ class TestAttributePreRunPartConstructor(unittest.TestCase):
 class TestAttributePreRunPartSetupHooks(unittest.TestCase):
     def setUp(self):
         self.name = "ShutterPart"
-        self.description = "This is a ShutterPart"
+        self.mri = "ML-SHUTTER-01"
         self.pre_run_value = "Open"
         self.reset_value = "Closed"
 
     def test_setup_sets_correct_hooks(self):
-        self.part = AttributePreRunPart(
-            self.name, self.description, self.pre_run_value, self.reset_value
+        part = AttributePreRunPart(
+            self.name, self.mri, self.pre_run_value, self.reset_value
         )
         registrar_mock = Mock()
-        self.part.setup(registrar_mock)
+        part.setup(registrar_mock)
 
         # Check calls
         calls = [
-            call(PreRunHook, self.part.on_pre_run),
-            call((PauseHook, AbortHook, PostRunReadyHook), self.part.on_reset),
+            call(PreRunHook, part.on_pre_run),
+            call((PauseHook, AbortHook, PostRunReadyHook), part.on_reset),
         ]
         registrar_mock.hook.assert_has_calls(calls)
 

--- a/tests/test_modules/test_scanning/test_directorymonitorpart.py
+++ b/tests/test_modules/test_scanning/test_directorymonitorpart.py
@@ -1,0 +1,72 @@
+import unittest
+
+from mock import Mock
+
+from malcolm.modules.scanning.hooks import ConfigureHook
+from malcolm.modules.scanning.parts import DirectoryMonitorPart
+
+
+class TestDirectoryMonitorPartConstructor(unittest.TestCase):
+    def setUp(self):
+        self.name = "DirectoryMonitorPart"
+        self.mri = "ML-DIRMON-01"
+
+    def test_attributes_are_initialised(self):
+        part = DirectoryMonitorPart(self.name, self.mri)
+
+        self.assertEqual(self.name, part.name)
+        self.assertEqual(self.mri, part.mri)
+
+
+class TestDirectoryMonitorPartSetupHooks(unittest.TestCase):
+    def setUp(self):
+        self.name = "DirectoryMonitorPart"
+        self.mri = "ML-DIRMON-01"
+
+    def test_hooks_are_set(self):
+        part = DirectoryMonitorPart(self.name, self.mri)
+
+        registrar_mock = Mock()
+        part.setup(registrar_mock)
+
+        registrar_mock.hook.assert_called_with(ConfigureHook, part.check_directories)
+
+
+class TestDirectoryMonitorPartCheckManagerMethod(unittest.TestCase):
+    def setUp(self):
+        self.name = "DirectoryMonitorPart"
+        self.mri = "ML-DIRMON-01"
+        self.hostname = "TEST-SERVER"
+        self.part = DirectoryMonitorPart(self.name, self.mri)
+        self.expected_bad_status_string = (
+            f"{self.mri}: bad directory monitor status for server {self.hostname}"
+        )
+
+        # Mocks
+        self.context = Mock(name="context")
+        self.child = Mock(name="child")
+        self.context.block_view.return_value = self.child
+        self.child.managerHostname.value = self.hostname
+
+    def test_method_checks_and_get_status(self):
+        self.part.setup(Mock())
+        self.part.check_directories(self.context)
+
+        self.child.managerCheck.assert_called_once
+        self.child.managerStatus.value.assert_called_once
+
+    def test_method_raises_ValueErorr_and_logs_for_bad_status_with_error_on_fail(self):
+        self.child.managerStatus.value = False
+        self.part.log = Mock(name="logger")
+
+        self.assertRaises(ValueError, self.part.check_directories, self.context)
+        self.part.log.error.assert_called_once_with(self.expected_bad_status_string)
+
+    def test_method_logs_error_for_bad_status_with_no_error_on_fail(self):
+        self.child.managerStatus.value = False
+        self.part.error_on_fail = False
+        self.part.log = Mock(name="logger")
+
+        self.part.check_directories(self.context)
+
+        self.part.log.error.assert_called_once_with(self.expected_bad_status_string)

--- a/tests/test_modules/test_scanning/test_directorymonitorpart.py
+++ b/tests/test_modules/test_scanning/test_directorymonitorpart.py
@@ -55,15 +55,19 @@ class TestDirectoryMonitorPartCheckManagerMethod(unittest.TestCase):
         self.child.managerCheck.assert_called_once
         self.child.managerStatus.value.assert_called_once
 
-    def test_method_raises_ValueErorr_and_logs_for_bad_status_with_error_on_fail(self):
-        self.child.managerStatus.value = False
+    def test_method_raises_ValueErorr_for_bad_managerCheck_status(self):
+        self.child.managerCheck = Mock(
+            name="managerCheck", side_effect=AssertionError()
+        )
         self.part.log = Mock(name="logger")
 
         self.assertRaises(ValueError, self.part.check_directories, self.context)
         self.part.log.error.assert_called_once_with(self.expected_bad_status_string)
 
-    def test_method_logs_error_for_bad_status_with_no_error_on_fail(self):
-        self.child.managerStatus.value = False
+    def test_method_logs_error_for_bad_managerCheck_status(self):
+        self.child.managerCheck = Mock(
+            name="managerCheck", side_effect=AssertionError()
+        )
         self.part.error_on_fail = False
         self.part.log = Mock(name="logger")
 


### PR DESCRIPTION
This adds a directory monitor block and part to check whether all of the expected file mounts and file mount types are correct for a particular server. The part checks during configure and by default will go into error (but otherwise can be set to just log an error in case you want the scan to proceed anyway with potential performance issues).

Also fixed the pandasettrigger for new version of isort and tidied up the AttributePreRunPart test file.