### PR TITLE
aravisGigE: allow setting trigger source

### DIFF
--- a/malcolm/modules/aravisGigE/blocks/aravisGigE_driver_block.yaml
+++ b/malcolm/modules/aravisGigE/blocks/aravisGigE_driver_block.yaml
@@ -15,3 +15,10 @@
 
 - ADCore.includes.adbase_parts:
     prefix: $(prefix)
+
+- ca.parts.CAChoicePart:
+    name: triggerSource
+    description: Detector trigger source
+    pv: $(prefix):TriggerSource
+    rbv_suffix: _RBV
+


### PR DESCRIPTION
This is needed in I22 to configure the scan, if it's not generally useful, a custom I22 aravisGigE block can be used instead, without affecting others.