### PR TITLE
Fix/pipfile lock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7']
+        python-version: [ '3.7' ]
 
     steps:
     - name: Checkout source

--- a/Pipfile
+++ b/Pipfile
@@ -27,7 +27,6 @@ mypy = "*"
 atomicwrites = "*"
 
 [packages]
-enum34 = "*"
 tornado = "*"
 numpy = "*"
 ruamel-yaml = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1d83a2813ec17c35fc1961282f639c2a48d63b91f2930fc79d9d252dd7aa77f5"
+            "sha256": "8916dd832608981ba2a358e764602c9feaaae37b09dd45ba6e8e271b10009b58"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,7 +23,6 @@
         },
         "backcall": {
             "hashes": [
-                "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
                 "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
             ],
             "version": "==0.2.0"
@@ -37,19 +36,9 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
-                "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
+                "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"
             ],
             "version": "==4.4.2"
-        },
-        "enum34": {
-            "hashes": [
-                "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53",
-                "sha256:c3858660960c984d6ab0ebad691265180da2b43f07e061c0f8dca9ef3cffd328",
-                "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"
-            ],
-            "index": "pypi",
-            "version": "==1.1.10"
         },
         "epicscorelibs": {
             "hashes": [
@@ -128,8 +117,7 @@
         },
         "ipython-genutils": {
             "hashes": [
-                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
-                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"
             ],
             "version": "==0.2.0"
         },
@@ -246,7 +234,6 @@
         },
         "pickleshare": {
             "hashes": [
-                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
                 "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
             ],
             "version": "==0.7.5"
@@ -347,6 +334,7 @@
         },
         "scanpointgenerator": {
             "hashes": [
+                "sha256:28672715d82ebf67f62d3d6632dddd5cb6132e62c71d7884fcfbe6a88aa6ebe5",
                 "sha256:9be4879200f2e17635ee215af8d86bb275dc654280c256a27950cdd8e8cdc7f6"
             ],
             "index": "pypi",
@@ -415,6 +403,7 @@
         },
         "vdsgen": {
             "hashes": [
+                "sha256:3429df0c6b0c5567db65c6a928ff061432e3c20b989d26ca7b48ef89f198317c",
                 "sha256:3eb61d229d510737b0f2bc8e48f9df7afef1c667abe680e0d55ff4df087ba213"
             ],
             "index": "pypi",
@@ -445,7 +434,6 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
                 "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
             ],
             "version": "==2.4.2"
@@ -565,7 +553,6 @@
         },
         "doc8": {
             "hashes": [
-                "sha256:4d1df12598807cf08ffa9a1d5ef42d229ee0de42519da01b768ff27211082c12",
                 "sha256:4d58a5c8c56cedd2b2c9d6e3153be5d956cf72f6051128f0f2255c66227df721"
             ],
             "index": "pypi",
@@ -645,27 +632,7 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
-                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
-                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
-                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
-                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
-                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
-                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
-                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
-                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
-                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
-                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
-                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
-                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
-                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
-                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
-                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
-                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
-                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
-                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
-                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
-                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383"
             ],
             "version": "==1.4.3"
         },
@@ -1093,7 +1060,8 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==3.7.4.3"
         },
         "urllib3": {
@@ -1105,7 +1073,8 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7",
+                "sha256:bb6349c100bf68b2d3ad4e79bfcd410c2974514c1388af6281b482f840f5d27b"
             ],
             "version": "==1.12.1"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8916dd832608981ba2a358e764602c9feaaae37b09dd45ba6e8e271b10009b58"
+            "sha256": "b7481b4d899b3a8aa8dc93c63225444c3567b778586a41b33ced6faabbf68ff2"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -1060,8 +1060,7 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "index": "pypi",
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "urllib3": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,12 +18,12 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    enum34
     tornado
     numpy
     ruamel.yaml
     h5py==2.9.0
     p4p
+    packaging
     pygelf
     plop
     annotypes


### PR DESCRIPTION
This PR updates the lock file with one generated in the Diamond Python environment so it should build everywhere even with --deploy (i.e. without needing to modify the lock file).

I have also removed enum34 as this is no longer needed for newer Python versions.

The packaging module was also added to setup.cfg as it was missing.