### PR TITLE
Fix/gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,12 @@
+variables:
+  SKIP_DOCS: 1 # This skips the template docs build
+
+
 include:
   - project: 'controls/reports/ci_templates'
     ref: master
     file: 'python3/dls_py3_template.yml'
-    variables:
-      SKIP_DOCS: 1 # This skips the template docs build
-
+    
 flake8:
   tags:
     - rhel7

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ include:
     ref: master
     file: 'python3/dls_py3_template.yml'
     variables:
-      SKIP_DOCS: 1 # This 
+      SKIP_DOCS: 1 # This skips the template docs build
 
 flake8:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,3 +2,19 @@ include:
   - project: 'controls/reports/ci_templates'
     ref: master
     file: 'python3/dls_py3_template.yml'
+    variables:
+      SKIP_DOCS: 1 # This 
+
+flake8:
+  tags:
+    - rhel7
+  stage: test
+  script:
+    - pipenv run flake8
+
+build_docs:
+  tags:
+    - rhel7
+  stage: test
+  script:
+    - pipenv run docs

--- a/tests/test_modules/test_ADPandABlocks/test_pandaseqtriggerpart.py
+++ b/tests/test_modules/test_ADPandABlocks/test_pandaseqtriggerpart.py
@@ -1,5 +1,4 @@
 import os
-import socket
 from datetime import datetime
 
 import pytest
@@ -513,7 +512,8 @@ class TestPandaSeqTriggerPart(ChildTestCase):
         self.gate_part.enable_set.assert_called_once()
 
     def test_configure_long_pcomp_row_trigger(self):
-        if "diamond.ac.uk" not in socket.gethostname():
+        # Skip on GitHub Actions and GitLab CI
+        if "CI" in os.environ:
             pytest.skip("performance test only")
 
         self.set_motor_attributes(

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -1,4 +1,3 @@
-import socket
 from datetime import datetime
 from os import environ
 
@@ -1096,7 +1095,8 @@ class TestPMACChildPart(ChildTestCase):
         assert elapsed.total_seconds() < 3.5
 
     def test_configure_long_trajectory(self):
-        if "diamond.ac.uk" not in socket.gethostname():
+        # Skip on GitHub Actions and GitLab CI
+        if "CI" in environ:
             pytest.skip("performance test only")
         # brick triggered
         self.long_configure(False)


### PR DESCRIPTION
I have updated the CI YAML to customise the docs build (it fails in the template so that is skipped using the flag) and add the separate flake8 check. The build now runs successfully on GitLab CI.

The two performance tests are now skipped based on the presence of the variable "CI" in the environment, which is present for both GitHub Actions and GitLac CI:

- https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
- https://docs.github.com/en/actions/reference/environment-variables