### PR TITLE
fix (?) kinematics parts to write all Q vars to VDS 

### DIFF
--- a/malcolm/modules/ADPandABlocks/parts/kinematicssavupart.py
+++ b/malcolm/modules/ADPandABlocks/parts/kinematicssavupart.py
@@ -396,6 +396,12 @@ class KinematicsSavuPart(builtin.parts.ChildPart):
                             layout,
                             fillvalue=-1,
                         )
+                    else:
+                        f.create_virtual_dataset(
+                            "/entry/rawQ" + "%02d" % (i + 1) + "." + datatype,
+                            layout,
+                            fillvalue=-1,
+                        )                      
 
             # Add any setpoint dimensions
             for dim in self.generator.dimensions:

--- a/malcolm/modules/ADPandABlocks/parts/kinematicssavupart.py
+++ b/malcolm/modules/ADPandABlocks/parts/kinematicssavupart.py
@@ -401,7 +401,7 @@ class KinematicsSavuPart(builtin.parts.ChildPart):
                             "/entry/rawQ" + "%02d" % (i + 1) + "." + datatype,
                             layout,
                             fillvalue=-1,
-                        )                      
+                        )
 
             # Add any setpoint dimensions
             for dim in self.generator.dimensions:


### PR DESCRIPTION
Comment seems to suggest it was meant to, nice to have for off-axis error checking.
Alternative or additional change would be to have all known scannables which are being transformed linked and named in the VDS (currently only the active axes are).
Almost definitely won't get time to merge this before leaving, so will likely need to be picked up.