### PR TITLE
Use packaging.version to parse git version for ManagerController's ve…

### DIFF
--- a/malcolm/modules/builtin/controllers/__init__.py
+++ b/malcolm/modules/builtin/controllers/__init__.py
@@ -11,6 +11,7 @@ from .managercontroller import (
     ATemplateDesigns,
     AUseGit,
     ManagerController,
+    check_git_version,
 )
 from .proxycontroller import AComms, AMri, APublish, ProxyController
 from .servercomms import ADescription, AMri, ServerComms

--- a/malcolm/modules/builtin/controllers/managercontroller.py
+++ b/malcolm/modules/builtin/controllers/managercontroller.py
@@ -1,10 +1,10 @@
 import os
 import socket
 import subprocess
-from distutils.version import StrictVersion
 from typing import Dict, List, Set, Tuple
 
 from annotypes import Anno, add_call_types, deserialize_object, json_decode, json_encode
+from packaging.version import parse
 
 from malcolm.compat import OrderedDict
 from malcolm.core import (
@@ -70,7 +70,7 @@ def check_git_version(required_version):
         )
     )
     version = output.decode("utf-8").replace("git version ", "").strip("\n")
-    return StrictVersion(version) >= StrictVersion(required_version)
+    return parse(version) >= parse(required_version)
 
 
 class ManagerController(StatefulController):


### PR DESCRIPTION
…rsion check

Due to not handling version numbers very well I have moved from distutils' StrictVersion to packaging.version in order to perform the git version check in ManagerController.

I also added some wonderful unit tests to demonstrate it working.