### PR TITLE
Update tutorials to use pipenv with Python 3

### DIFF
--- a/docs/tutorials/areadetector.rst
+++ b/docs/tutorials/areadetector.rst
@@ -358,16 +358,11 @@ button.
 
 Let's start up the example and see it in action::
 
-    [me@mypc pymalcolm]$ ./malcolm/imalcolm.py malcolm/modules/demo/DEMO-AREADETECTOR.yaml
-    Loading...
-    Python 2.7.13 (default, Oct  3 2017, 11:17:53)
-    Type "copyright", "credits" or "license" for more information.
-
-    IPython 5.4.1 -- An enhanced Interactive Python.
-    ?         -> Introduction and overview of IPython's features.
-    %quickref -> Quick reference.
-    help      -> Python's own help system.
-    object?   -> Details about 'object', use 'object??' for extra details.
+    [me@mypc pymalcolm]$ pipenv run imalcolm malcolm/modules/demo/DEMO-AREADETECTOR.yaml
+    Loading malcolm...
+    Python 3.7.2 (default, Jan 20 2020, 11:03:41)
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
 
 
     Welcome to iMalcolm.

--- a/docs/tutorials/counter.rst
+++ b/docs/tutorials/counter.rst
@@ -142,16 +142,11 @@ There is a web GUI that ships with pymalcolm, called `malcolmjs`_. We can use it
 to play with this counter block and see how it works. Let's launch our demo
 again::
 
-    [me@mypc pymalcolm]$ ./malcolm/imalcolm.py malcolm/modules/demo/DEMO-HELLO.yaml
-    Loading...
-    Python 2.7.13 (default, Oct  3 2017, 11:17:53)
-    Type "copyright", "credits" or "license" for more information.
-
-    IPython 5.4.1 -- An enhanced Interactive Python.
-    ?         -> Introduction and overview of IPython's features.
-    %quickref -> Quick reference.
-    help      -> Python's own help system.
-    object?   -> Details about 'object', use 'object??' for extra details.
+    [me@mypc pymalcolm]$ pipenv run imalcolm malcolm/modules/demo/DEMO-HELLO.yaml
+    Loading malcolm...
+    Python 3.7.2 (default, Jan 20 2020, 11:03:41)
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
 
 
     Welcome to iMalcolm.

--- a/docs/tutorials/detector.rst
+++ b/docs/tutorials/detector.rst
@@ -344,17 +344,11 @@ Running the demo
 
 Let's run up the example and give it a go::
 
-    [me@mypc pymalcolm]$ ./malcolm/imalcolm.py malcolm/modules/demo/DEMO-DETECTOR.yaml
-    Loading...
-    Python 2.7.13 (default, Oct  3 2017, 11:17:53)
-    Type "copyright", "credits" or "license" for more information.
-
-    IPython 5.4.1 -- An enhanced Interactive Python.
-    ?         -> Introduction and overview of IPython's features.
-    %quickref -> Quick reference.
-    help      -> Python's own help system.
-    object?   -> Details about 'object', use 'object??' for extra details.
-
+    [me@mypc pymalcolm]$ pipenv run imalcolm malcolm/modules/demo/DEMO-DETECTOR.yaml
+    Loading malcolm...
+    Python 3.7.2 (default, Jan 20 2020, 11:03:41)
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
 
     Welcome to iMalcolm.
 

--- a/docs/tutorials/hello.rst
+++ b/docs/tutorials/hello.rst
@@ -3,8 +3,9 @@
 Hello World Tutorial
 ====================
 
-If you have followed the `installation_guide` you will have a checked out a
-copy of pymalcolm which includes some example code.
+If you have followed the `installation_guide` using pipenv you will have a
+checked out a copy of pymalcolm, which includes some example code, and a
+virtual environment ready for running Malcolm.
   
 So now would be a good time for a "Hello World" tutorial.
 
@@ -22,7 +23,7 @@ So how do we launch a Malcolm process?
 
 The simplest way is to use the imalcolm application. It will be installed on the
 system as ``imalcolm``, but you can use it from your checked out copy of
-pymalcolm by running ``./malcolm/imalcolm.py``. You also need to tell imalcolm
+pymalcolm by running ``pipenv run imalcolm``. You also need to tell imalcolm
 what Blocks it should instantiate and what Comms modules it should use by
 writing a `YAML`_ `process_definition_` file.
 
@@ -42,16 +43,11 @@ process or a web GUI.
 
 Let's run it now::
 
-    [me@mypc pymalcolm]$ ./malcolm/imalcolm.py malcolm/modules/demo/DEMO-HELLO.yaml
-    Loading...
-    Python 2.7.13 (default, Oct  3 2017, 11:17:53)
-    Type "copyright", "credits" or "license" for more information.
-
-    IPython 5.4.1 -- An enhanced Interactive Python.
-    ?         -> Introduction and overview of IPython's features.
-    %quickref -> Quick reference.
-    help      -> Python's own help system.
-    object?   -> Details about 'object', use 'object??' for extra details.
+    [me@mypc pymalcolm]$ pipenv run imalcolm malcolm/modules/demo/DEMO-HELLO.yaml
+    Loading malcolm...
+    Python 3.7.2 (default, Jan 20 2020, 11:03:41)
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
 
 
     Welcome to iMalcolm.
@@ -106,16 +102,11 @@ Well if we start a second imalcolm session we can tell it to connect to the
 first session, get the HELLO block from the first Process, and run a Method
 on it::
 
-    [me@mypc pymalcolm]$ ./malcolm/imalcolm.py -c ws://localhost:8008
-    Loading...
-    Python 2.7.13 (default, Oct  3 2017, 11:17:53)
-    Type "copyright", "credits" or "license" for more information.
-
-    IPython 5.4.1 -- An enhanced Interactive Python.
-    ?         -> Introduction and overview of IPython's features.
-    %quickref -> Quick reference.
-    help      -> Python's own help system.
-    object?   -> Details about 'object', use 'object??' for extra details.
+    [me@mypc pymalcolm]$ pipenv run imalcolm -c ws://localhost:8008
+    Loading malcolm...
+    Python 3.7.2 (default, Jan 20 2020, 11:03:41)
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
 
 
     Welcome to iMalcolm.

--- a/docs/tutorials/motion.rst
+++ b/docs/tutorials/motion.rst
@@ -299,7 +299,7 @@ CounterMoveParts, ``x`` and ``y``, so the resulting Block should have ``xMove()`
 and ``yMove()`` Methods. The ``needs_context=True`` argument tells Malcolm that
 when the move Method is called, it should be passed a `context_` object as the
 first argument. This utility object makes us a `Block` view so we can interact
-with our child Block
+with our child Block.
 
 Finally we define the ``move()`` Method. As well as the `Context` we requested,
 it takes arguments ``demand`` and ``duration`` which are described by annotypes.
@@ -314,16 +314,11 @@ How it looks in the GUI
 
 Let's run up the demo and see how it looks in the GUI::
 
-    [me@mypc pymalcolm]$ ./malcolm/imalcolm.py malcolm/modules/demo/DEMO-MOTION.yaml
-    Loading...
-    Python 2.7.13 (default, Oct  3 2017, 11:17:53)
-    Type "copyright", "credits" or "license" for more information.
-
-    IPython 5.4.1 -- An enhanced Interactive Python.
-    ?         -> Introduction and overview of IPython's features.
-    %quickref -> Quick reference.
-    help      -> Python's own help system.
-    object?   -> Details about 'object', use 'object??' for extra details.
+    [me@mypc pymalcolm]$ pipenv run imalcolm malcolm/modules/demo/DEMO-MOTION.yaml
+    Loading malcolm...
+    Python 3.7.2 (default, Jan 20 2020, 11:03:41)
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
 
 
     Welcome to iMalcolm.

--- a/docs/tutorials/pmac.rst
+++ b/docs/tutorials/pmac.rst
@@ -70,7 +70,7 @@ Define the Process Definition
 
 Let's make a Process Definition in ``etc/malcolm/BLxxI-ML-MALC-01.yaml``::
 
-    #!/dls_sw/prod/common/python/RHEL7-x86_64/pymalcolm/4-x/prefix/bin/imalcolm
+    #!/dls_sw/prod/tools/RHEL7-x86_64/defaults/bin/imalcolm
 
     # Define the directory that this YAML file lives in as a Malcolm module
     # so we can use Blocks defined there as BLxxI.blocks.yyy
@@ -124,7 +124,16 @@ The first thing to note is the ``#!`` line at the top of the file. This means
 that we can make the YAML file executable, and when it is executed
 ``imalcolm.py`` will be run with the path of the YAML file passed as an
 argument. The full path to ``imalcolm.py`` allows us to pin to a particular
-version of Malcolm.
+version of Malcolm. The example above will used the configured tool version of
+Malcolm, which is usually the latest release. But this can be pinned to a
+specific version, with the example below for 4.4::
+
+    #!/dls_sw/prod/python3/RHEL7-x86_64/pymalcolm/4.4/prefix/bin/imalcolm
+
+Alternatively, you can also run from a created virtual environment from a
+checked-out version of Malcolm using::
+
+    [me@mypc pymalcolm]$ pipenv run /path/to/yaml/dir/BLxxI-ML-MALC-01.yaml
 
 After this, we've defined a ``BLxxI`` module, and created two beamline specific
 Blocks from it (``brick01_block`` and ``scan_block``), and then

--- a/docs/tutorials/pmac.rst
+++ b/docs/tutorials/pmac.rst
@@ -70,7 +70,7 @@ Define the Process Definition
 
 Let's make a Process Definition in ``etc/malcolm/BLxxI-ML-MALC-01.yaml``::
 
-    #!/dls_sw/prod/tools/RHEL7-x86_64/defaults/bin/imalcolm
+    #!/dls_sw/prod/python3/RHEL7-x86_64/pymalcolm/4.4/prefix/bin/imalcolm
 
     # Define the directory that this YAML file lives in as a Malcolm module
     # so we can use Blocks defined there as BLxxI.blocks.yyy
@@ -124,11 +124,11 @@ The first thing to note is the ``#!`` line at the top of the file. This means
 that we can make the YAML file executable, and when it is executed
 ``imalcolm.py`` will be run with the path of the YAML file passed as an
 argument. The full path to ``imalcolm.py`` allows us to pin to a particular
-version of Malcolm. The example above will used the configured tool version of
-Malcolm, which is usually the latest release. But this can be pinned to a
-specific version, with the example below for 4.4::
+version of Malcolm - with the example above using the 4.4 release version. You
+can also use the configured tool version, which is usually the latest
+release, with the following path::
 
-    #!/dls_sw/prod/python3/RHEL7-x86_64/pymalcolm/4.4/prefix/bin/imalcolm
+    #!/dls_sw/prod/tools/RHEL7-x86_64/defaults/bin/imalcolm
 
 Alternatively, you can also run from a created virtual environment from a
 checked-out version of Malcolm using::

--- a/docs/tutorials/scanning.rst
+++ b/docs/tutorials/scanning.rst
@@ -277,16 +277,11 @@ Running a Scan
 
 Let's start up the example and see it in action::
 
-    [me@mypc pymalcolm]$ ./malcolm/imalcolm.py malcolm/modules/demo/DEMO-SCANNING.yaml
-    Loading...
-    Python 2.7.13 (default, Oct  3 2017, 11:17:53)
-    Type "copyright", "credits" or "license" for more information.
-
-    IPython 5.4.1 -- An enhanced Interactive Python.
-    ?         -> Introduction and overview of IPython's features.
-    %quickref -> Quick reference.
-    help      -> Python's own help system.
-    object?   -> Details about 'object', use 'object??' for extra details.
+    [me@mypc pymalcolm]$ pipenv run imalcolm malcolm/modules/demo/DEMO-SCANNING.yaml
+    Loading malcolm...
+    Python 3.7.2 (default, Jan 20 2020, 11:03:41)
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
 
 
     Welcome to iMalcolm.


### PR DESCRIPTION
Updated the tutorials based on using pipenv.

I have also updated the pmac's shebang to use the default Malcolm version configured from configure-tool, as well as comment on the alternatives available.