### PR TITLE
GitHub Actions: define explicit version of Python for pipenv and tidy…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,11 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v2
       with:
-          # require all of history to see all tagged versions' docs
-          fetch-depth: 0
+        # require all of history to see all tagged versions' docs
+        fetch-depth: 0
+
+    - name: Install packages
+      run: sudo apt-get install graphviz
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -55,14 +58,11 @@ jobs:
     - name: Set EPICS Base path
       run: echo "EPICS_BASE=`pwd`/${EPICS_BASE_DIR}" >> $GITHUB_ENV
 
-    - name: Install packages
-      run: sudo apt-get install graphviz
-
     - name: Install Python dependencies
       run: |
         env
         pip install pipenv
-        pipenv install --dev --deploy && pipenv graph
+        pipenv install --dev --deploy --python ${{ matrix.python-version }} && pipenv graph
 
     - name: Create Sdist and Wheel
       # for reproducible builds set SOURCE_DATE_EPOCH to the date of the last commit


### PR DESCRIPTION
… up workflow

Whilst pip and Python paths seem to be correctly pointing to the Python 3.7 version installed by an action in the GitHub Actions Workflow, pipenv instead seems to prefer the newest version of Python available by default.

On ubuntu-latest this is now 3.8 which does not match the intended version (the build fails, but that should be fixed as part of another PR). An example Action with pipenv using the system's Python 3.8 is: https://github.com/dls-controls/pymalcolm/runs/2167647891?check_suite_focus=true - where the following line can be seen:

`Using /usr/bin/python3.8 (3.8.5) to create virtualenv...`

This PR explicitly fixes the version of Python for pipenv to use with --python.