### PR TITLE
Fix /tmp becoming a git repo

### DIFF
--- a/tests/test_modules/test_ADCore/test_hdfwriterpart.py
+++ b/tests/test_modules/test_ADCore/test_hdfwriterpart.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from xml.etree import ElementTree
 
 import cothread
@@ -16,6 +17,7 @@ from malcolm.modules.ADCore.infos import (
 from malcolm.modules.ADCore.parts import HDFWriterPart
 from malcolm.modules.ADCore.parts.hdfwriterpart import greater_than_zero
 from malcolm.modules.ADCore.util import AttributeDatasetType
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.scanning.controllers import RunnableController
 from malcolm.modules.scanning.util import DatasetType
 from malcolm.testutil import ChildTestCase
@@ -138,15 +140,17 @@ class TestHDFWriterPart(ChildTestCase):
         self.child = self.create_child_block(
             hdf_writer_block, self.process, mri="BLOCK:HDF5", prefix="prefix"
         )
+        self.config_dir = tmp_dir("config_dir")
         self.process.start()
 
     def tearDown(self):
         self.process.stop(2)
+        shutil.rmtree(self.config_dir.value)
 
     def test_init(self):
         self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
         self.context.set_notify_dispatch_request(self.o.notify_dispatch_request)
-        c = RunnableController("mri", "/tmp")
+        c = RunnableController("mri", self.config_dir.value)
         c.add_part(self.o)
         self.process.add_controller(c)
         b = c.block_view()

--- a/tests/test_modules/test_ADPandABlocks/test_pandaalternatingdivpart.py
+++ b/tests/test_modules/test_ADPandABlocks/test_pandaalternatingdivpart.py
@@ -12,7 +12,7 @@ class TestPandAAlternatingDivPart(ChildTestCase):
         self.context = Context(self.process)
 
         # Create a PandA to which this part communicates
-        self.panda = ManagerController("ML-PANDA-01", "/tmp")
+        self.panda = ManagerController("ML-PANDA-01", "/tmp", use_git=False)
 
         # Create a block for this part
         self.child = self.create_child_block(

--- a/tests/test_modules/test_ADPandABlocks/test_pandablocksrunnablecontroller.py
+++ b/tests/test_modules/test_ADPandABlocks/test_pandablocksrunnablecontroller.py
@@ -35,7 +35,9 @@ class PandABlocksRunnableControllerTest(unittest.TestCase):
     def setUp(self, mock_client, mock_adbase_parts):
         mock_adbase_parts.return_value = ([], [])
         self.process = Process()
-        self.o = PandARunnableController(mri="P", config_dir="/tmp", prefix="PV:")
+        self.o = PandARunnableController(
+            mri="P", config_dir="/tmp", prefix="PV:", use_git=False
+        )
         self.o.add_part(DatasetTablePart("DSET"))
         self.client = self.o._client
         self.client.started = False

--- a/tests/test_modules/test_ADPandABlocks/test_pandaseqtriggerpart.py
+++ b/tests/test_modules/test_ADPandABlocks/test_pandaseqtriggerpart.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from datetime import datetime
 
 import pytest
@@ -15,6 +16,7 @@ from malcolm.modules.ADPandABlocks.util import (
     Trigger,
 )
 from malcolm.modules.builtin.controllers import BasicController, ManagerController
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.builtin.parts import ChildPart
 from malcolm.modules.builtin.util import ExportTable
 from malcolm.modules.pandablocks.util import PositionCapture
@@ -81,7 +83,7 @@ class TestPandaSeqTriggerPart(ChildTestCase):
         self.context = Context(self.process)
 
         # Create a fake PandA
-        self.panda = ManagerController("PANDA", "/tmp")
+        self.panda = ManagerController("PANDA", "/tmp", use_git=False)
         self.busses = PositionsPart("busses")
         self.panda.add_part(self.busses)
 
@@ -120,8 +122,12 @@ class TestPandaSeqTriggerPart(ChildTestCase):
             os.path.join(os.path.dirname(__file__), "..", "test_pmac", "blah"),
             "test_pmac_manager_block.yaml",
         )
+        self.config_dir = tmp_dir("config_dir")
         self.pmac = self.create_child_block(
-            pmac_block, self.process, mri_prefix="PMAC", config_dir="/tmp"
+            pmac_block,
+            self.process,
+            mri_prefix="PMAC",
+            config_dir=self.config_dir.value,
         )
         # These are the motors we are interested in
         self.child_x = self.process.get_controller("BL45P-ML-STAGE-01:X")
@@ -156,6 +162,7 @@ class TestPandaSeqTriggerPart(ChildTestCase):
 
     def tearDown(self):
         self.process.stop(timeout=2)
+        shutil.rmtree(self.config_dir.value)
 
     def set_motor_attributes(
         self,

--- a/tests/test_modules/test_builtin/test_childpart.py
+++ b/tests/test_modules/test_builtin/test_childpart.py
@@ -1,3 +1,4 @@
+import shutil
 import unittest
 
 from malcolm.core import (
@@ -10,6 +11,7 @@ from malcolm.core import (
     config_tag,
 )
 from malcolm.modules.builtin.controllers import BasicController, ManagerController
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.builtin.infos import SinkPortInfo, SourcePortInfo
 from malcolm.modules.builtin.parts import ChildPart
 from malcolm.modules.builtin.util import AVisibleArray, LayoutTable
@@ -58,7 +60,8 @@ class TestChildPart(unittest.TestCase):
         self.c3._block.sinkportConnector.set_value("Connector2")
 
         # create a root block for the child blocks to reside in
-        self.c = ManagerController(mri="mainBlock", config_dir="/tmp")
+        self.config_dir = tmp_dir("config_dir")
+        self.c = ManagerController(mri="mainBlock", config_dir=self.config_dir.value)
         for part in [self.p1, self.p2, self.p3]:
             self.c.add_part(part)
         self.p.add_controller(self.c)
@@ -71,6 +74,7 @@ class TestChildPart(unittest.TestCase):
 
     def tearDown(self):
         self.p.stop(timeout=1)
+        shutil.rmtree(self.config_dir.value)
 
     def test_init(self):
         for controller in (self.c1, self.c2, self.c3):

--- a/tests/test_modules/test_demo/test_detector_block.py
+++ b/tests/test_modules/test_demo/test_detector_block.py
@@ -9,6 +9,7 @@ from cothread import cothread
 from scanpointgenerator import CompoundGenerator, LineGenerator
 
 from malcolm.core import Process
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.demo.blocks import detector_block
 from malcolm.modules.scanning.util import DatasetType
 
@@ -16,7 +17,8 @@ from malcolm.modules.scanning.util import DatasetType
 class TestDetectorBlock(unittest.TestCase):
     def setUp(self):
         self.p = Process("proc")
-        for c in detector_block("mri", config_dir="/tmp"):
+        self.config_dir = tmp_dir("config_dir")
+        for c in detector_block("mri", config_dir=self.config_dir.value):
             self.p.add_controller(c)
         self.p.start()
         self.b = self.p.block_view("mri")
@@ -25,6 +27,7 @@ class TestDetectorBlock(unittest.TestCase):
     def tearDown(self):
         self.p.stop(timeout=2)
         shutil.rmtree(self.tmpdir)
+        shutil.rmtree(self.config_dir.value)
 
     def test_init(self):
         assert list(self.b) == [

--- a/tests/test_modules/test_demo/test_motion_block.py
+++ b/tests/test_modules/test_demo/test_motion_block.py
@@ -1,13 +1,16 @@
+import shutil
 import unittest
 
 from malcolm.core import Process
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.demo.blocks import motion_block
 
 
 class TestMotionBlock(unittest.TestCase):
     def setUp(self):
         self.p = Process("proc")
-        for c in motion_block("mri", config_dir="/tmp"):
+        self.config_dir = tmp_dir("config_dir")
+        for c in motion_block("mri", config_dir=self.config_dir.value):
             self.p.add_controller(c)
         self.p.start()
         self.b = self.p.block_view("mri")
@@ -16,6 +19,7 @@ class TestMotionBlock(unittest.TestCase):
 
     def tearDown(self):
         self.p.stop()
+        shutil.rmtree(self.config_dir.value)
 
     def test_move(self):
         assert self.bx.counter.value == 0

--- a/tests/test_modules/test_demo/test_scan_block.py
+++ b/tests/test_modules/test_demo/test_scan_block.py
@@ -5,6 +5,7 @@ import unittest
 from scanpointgenerator import CompoundGenerator, LineGenerator
 
 from malcolm.core import Process
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.demo.blocks import detector_block, motion_block, scan_1det_block
 from malcolm.modules.scanning.util import DatasetType, DetectorTable
 from malcolm.testutil import PublishController
@@ -13,10 +14,11 @@ from malcolm.testutil import PublishController
 class TestScanBlock(unittest.TestCase):
     def setUp(self):
         self.p = Process("proc")
+        self.config_dir = tmp_dir("config_dir")
         for c in (
-            detector_block("DETECTOR", config_dir="/tmp")
-            + motion_block("MOTION", config_dir="/tmp")
-            + scan_1det_block("SCANMRI", config_dir="/tmp")
+            detector_block("DETECTOR", config_dir=self.config_dir.value)
+            + motion_block("MOTION", config_dir=self.config_dir.value)
+            + scan_1det_block("SCANMRI", config_dir=self.config_dir.value)
         ):
             self.p.add_controller(c)
         self.pub = PublishController("PUB")
@@ -29,6 +31,7 @@ class TestScanBlock(unittest.TestCase):
     def tearDown(self):
         self.p.stop(timeout=2)
         shutil.rmtree(self.tmpdir)
+        shutil.rmtree(self.config_dir.value)
 
     def test_init(self):
         assert self.b.label.value == "Mapping x, y with demo detector"

--- a/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
+++ b/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
@@ -1,9 +1,11 @@
+import shutil
 import unittest
 from collections import OrderedDict
 
 from mock import ANY, patch
 
 from malcolm.core import Process, Queue, Subscribe
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.pandablocks.controllers import PandAManagerController
 from malcolm.modules.pandablocks.pandablocksclient import BlockData, FieldData
 from malcolm.modules.pandablocks.util import BitsTable, PositionCapture
@@ -16,7 +18,10 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
     )
     def setUp(self, mock_client):
         self.process = Process()
-        self.o = PandAManagerController(mri="P", config_dir="/tmp", poll_period=1000)
+        self.config_dir = tmp_dir("config_dir")
+        self.o = PandAManagerController(
+            mri="P", config_dir=self.config_dir.value, poll_period=1000
+        )
         self.client = self.o._client
         self.client.started = False
         blocks_data = OrderedDict()
@@ -60,6 +65,7 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
 
     def tearDown(self):
         self.process.stop()
+        shutil.rmtree(self.config_dir.value)
 
     def test_initial_changes(self):
         assert self.process.mri_list == [

--- a/tests/test_modules/test_pmac/test_cspart.py
+++ b/tests/test_modules/test_pmac/test_cspart.py
@@ -14,7 +14,7 @@ class TestCSPart(ChildTestCase):
             cs_block, self.process, mri="PMAC:CS1", pv_prefix="PV:PRE"
         )
         self.set_attributes(self.child, port="PMAC2CS1")
-        c = ManagerController("PMAC", "/tmp")
+        c = ManagerController("PMAC", "/tmp", use_git=False)
         c.add_part(CSPart(mri="PMAC:CS1", cs=1))
         self.process.add_controller(c)
         self.process.start()

--- a/tests/test_modules/test_pmac/test_motorpremovepart.py
+++ b/tests/test_modules/test_pmac/test_motorpremovepart.py
@@ -20,7 +20,7 @@ class TestMotorPreMovePart(ChildTestCase):
         # Add Beam Selector object
         self.o = MotorPreMovePart(name="MotorPreMovePart", mri="BS", demand=50)
 
-        controller = RunnableController("SCAN", "/tmp")
+        controller = RunnableController("SCAN", "/tmp", use_git=False)
         controller.add_part(self.o)
 
         self.process.add_controller(controller)

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -1,3 +1,4 @@
+import shutil
 from datetime import datetime
 from os import environ
 
@@ -7,6 +8,7 @@ from mock import ANY, Mock, call, patch
 from scanpointgenerator import CompoundGenerator, LineGenerator, StaticPointGenerator
 
 from malcolm.core import Context, Process
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.pmac.parts import PmacChildPart
 from malcolm.modules.scanning.infos import (
     MinTurnaroundInfo,
@@ -21,9 +23,13 @@ class TestPMACChildPart(ChildTestCase):
     def setUp(self):
         self.process = Process("Process")
         self.context = Context(self.process)
+        self.config_dir = tmp_dir("config_dir")
         pmac_block = make_block_creator(__file__, "test_pmac_manager_block.yaml")
         self.child = self.create_child_block(
-            pmac_block, self.process, mri_prefix="PMAC", config_dir="/tmp"
+            pmac_block,
+            self.process,
+            mri_prefix="PMAC",
+            config_dir=self.config_dir.value,
         )
         # These are the child blocks we are interested in
         self.child_x = self.process.get_controller("BL45P-ML-STAGE-01:X")
@@ -40,6 +46,7 @@ class TestPMACChildPart(ChildTestCase):
     def tearDown(self):
         del self.context
         self.process.stop(timeout=1)
+        shutil.rmtree(self.config_dir.value)
 
     # TODO: restore this tests when GDA does units right
     def test_bad_units(self):

--- a/tests/test_modules/test_pmac/test_pmacstatuspart.py
+++ b/tests/test_modules/test_pmac/test_pmacstatuspart.py
@@ -12,7 +12,7 @@ class TestPmacStatusPart(ChildTestCase):
             pmac_status_block, self.process, mri="my_mri", pv_prefix="PV:PRE"
         )
         self.set_attributes(child, i10=1705244)
-        c = ManagerController("PMAC", "/tmp")
+        c = ManagerController("PMAC", "/tmp", use_git=False)
         self.o = PmacStatusPart(name="part", mri="my_mri", initial_visibility=True)
         c.add_part(self.o)
         self.process.add_controller(c)

--- a/tests/test_modules/test_pmac/test_pmactrajectorypart.py
+++ b/tests/test_modules/test_pmac/test_pmactrajectorypart.py
@@ -19,7 +19,7 @@ class TestPMACTrajectoryPart(ChildTestCase):
         self.child = self.create_child_block(
             pmac_trajectory_block, self.process, mri="PMAC:TRAJ", pv_prefix="PV:PRE"
         )
-        c = ManagerController("PMAC", "/tmp")
+        c = ManagerController("PMAC", "/tmp", use_git=False)
         self.o = PmacTrajectoryPart(name="pmac", mri="PMAC:TRAJ")
         c.add_part(self.o)
         self.process.add_controller(c)

--- a/tests/test_modules/test_pva/test_system_pva.py
+++ b/tests/test_modules/test_pva/test_system_pva.py
@@ -8,6 +8,7 @@ from scanpointgenerator import CompoundGenerator, LineGenerator
 
 from malcolm.core import Process
 from malcolm.modules.builtin.blocks import proxy_block
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.builtin.util import ExportTable
 from malcolm.modules.demo.blocks import detector_block, motion_block
 from malcolm.modules.pva.blocks import pva_client_block, pva_server_block
@@ -16,8 +17,9 @@ from malcolm.modules.pva.blocks import pva_client_block, pva_server_block
 class TestSystemDetectorPVA(unittest.TestCase):
     def setUp(self):
         self.process = Process("proc")
+        self.config_dir = tmp_dir("config_dir")
         for controller in detector_block(
-            mri="TESTDET", config_dir="/tmp"
+            mri="TESTDET", config_dir=self.config_dir.value
         ) + pva_server_block(mri="PVA-SERVER"):
             self.process.add_controller(controller)
         self.process.start()
@@ -33,6 +35,7 @@ class TestSystemDetectorPVA(unittest.TestCase):
         self.process.stop(timeout=2)
         self.process2.stop(timeout=2)
         shutil.rmtree(self.tmpdir)
+        shutil.rmtree(self.config_dir.value)
 
     def make_generator(self):
         line1 = LineGenerator("y", "mm", 0, 3, 3)
@@ -160,8 +163,9 @@ class TestSystemDetectorPVA(unittest.TestCase):
 class TestSystemMotionPVA(unittest.TestCase):
     def setUp(self):
         self.process = Process("proc")
+        self.config_dir = tmp_dir("config_dir")
         for controller in motion_block(
-            mri="TESTMOTION", config_dir="/tmp"
+            mri="TESTMOTION", config_dir=self.config_dir.value
         ) + pva_server_block(mri="PVA-SERVER"):
             self.process.add_controller(controller)
         self.process.start()
@@ -171,6 +175,9 @@ class TestSystemMotionPVA(unittest.TestCase):
         ):
             self.process2.add_controller(controller)
         self.process2.start()
+
+    def tearDown(self):
+        shutil.rmtree(self.config_dir.value)
 
     def test_exports(self):
         block = self.process2.block_view("TESTMOTION")

--- a/tests/test_modules/test_scanning/test_runnablecontroller.py
+++ b/tests/test_modules/test_scanning/test_runnablecontroller.py
@@ -1,3 +1,4 @@
+import shutil
 import unittest
 
 import cothread
@@ -19,6 +20,7 @@ from malcolm.core import (
     Process,
 )
 from malcolm.modules import builtin, scanning
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.demo.blocks import motion_block
 from malcolm.modules.demo.parts import MotionChildPart
 from malcolm.modules.demo.parts.motionchildpart import AExceptionStep
@@ -237,14 +239,15 @@ class TestRunnableController(unittest.TestCase):
         self.context = Context(self.p)
 
         # Make a motion block to act as our child
-        for c in motion_block(mri="childBlock", config_dir="/tmp"):
+        self.config_dir = tmp_dir("config_dir")
+        for c in motion_block(mri="childBlock", config_dir=self.config_dir.value):
             self.p.add_controller(c)
         self.b_child = self.context.block_view("childBlock")
 
         part = MisbehavingPart(mri="childBlock", name="part", initial_visibility=True)
 
         # create a root block for the RunnableController block to reside in
-        self.c = RunnableController(mri="mainBlock", config_dir="/tmp")
+        self.c = RunnableController(mri="mainBlock", config_dir=self.config_dir.value)
         self.c.add_part(part)
         self.p.add_controller(self.c)
         self.b = self.context.block_view("mainBlock")
@@ -257,6 +260,7 @@ class TestRunnableController(unittest.TestCase):
 
     def tearDown(self):
         self.p.stop(timeout=1)
+        shutil.rmtree(self.config_dir.value)
 
     def checkState(self, state):
         assert self.c.state.value == state
@@ -585,12 +589,13 @@ class TestRunnableControllerBreakpoints(unittest.TestCase):
         self.context2 = Context(self.p2)
 
         # Make a motion block to act as our child
-        for c in motion_block(mri="childBlock", config_dir="/tmp"):
+        self.config_dir = tmp_dir("config_dir")
+        for c in motion_block(mri="childBlock", config_dir=self.config_dir.value):
             self.p.add_controller(c)
         self.b_child = self.context.block_view("childBlock")
 
         # create a root block for the RunnableController block to reside in
-        self.c = RunnableController(mri="mainBlock", config_dir="/tmp")
+        self.c = RunnableController(mri="mainBlock", config_dir=self.config_dir.value)
         self.p.add_controller(self.c)
         self.b = self.context.block_view("mainBlock")
         self.ss = self.c.state_set
@@ -602,6 +607,7 @@ class TestRunnableControllerBreakpoints(unittest.TestCase):
 
     def tearDown(self):
         self.p.stop(timeout=1)
+        shutil.rmtree(self.config_dir.value)
 
     def checkState(self, state):
         assert self.c.state.value == state

--- a/tests/test_modules/test_scanning/test_simultaneousaxespart.py
+++ b/tests/test_modules/test_scanning/test_simultaneousaxespart.py
@@ -20,7 +20,7 @@ class TestSimultaneousAxesPart(unittest.TestCase):
         self.process = Process("proc")
         self.process.start()
         self.addCleanup(self.process.stop, 2)
-        c = RunnableController("mri", "/tmp")
+        c = RunnableController("mri", "/tmp", use_git=False)
         c.add_part(self.o)
         self.process.add_controller(c)
         self.b = c.block_view()

--- a/tests/test_modules/test_scanning/test_unrollingpart.py
+++ b/tests/test_modules/test_scanning/test_unrollingpart.py
@@ -1,8 +1,10 @@
+import shutil
 import unittest
 
 from scanpointgenerator import CompoundGenerator, LineGenerator, SquashingExcluder
 
 from malcolm.core import Process
+from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.scanning.controllers import RunnableController
 from malcolm.modules.scanning.parts import UnrollingPart
 
@@ -29,10 +31,14 @@ class TestUnrollingPart(unittest.TestCase):
         self.process = Process("proc")
         self.process.start()
         self.addCleanup(self.process.stop, 2)
-        c = RunnableController("mri", "/tmp")
+        self.config_dir = tmp_dir("config_dir")
+        c = RunnableController("mri", self.config_dir.value)
         c.add_part(self.o)
         self.process.add_controller(c)
         self.b = c.block_view()
+
+    def tearDown(self):
+        shutil.rmtree(self.config_dir.value)
 
     def test_2d_generator(self):
         generator = make_generator()


### PR DESCRIPTION
This fixes #326.

I have made use of temporary directories using builtin.defines.tmp_dir() where necessary for tests and instantiating blocks and also delete the created directory in tearDown.

Other places I have passed use_git=False - generally where the controllers are instantiated directly and can't see a benefit from enabling git.

I ran all tests and confirmed that /tmp is no longer a git repo afterwards.