### PR TITLE
Add template designs to package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
 malcolm =
     modules/*/*/*.yaml
     modules/*/*/*.svg
+    modules/*/*/*/*.json
     modules/system/db/*.template
     modules/web/www/*
     modules/web/www/static/css/*


### PR DESCRIPTION
Template designs provided by some modules (demo, ADSimDetector and ADPandABlocks) were missing from the Malcolm build when installing into prefix.