### PR TITLE
Restore default ChildPart.initial_visibility=None

### DIFF
--- a/malcolm/modules/builtin/parts/childpart.py
+++ b/malcolm/modules/builtin/parts/childpart.py
@@ -67,6 +67,7 @@ with Anno(
     "means only if child Source/Sink Ports connect to another Block"
 ):
     AInitialVisibility = bool
+UInitialVisibility = Optional[AInitialVisibility]
 with Anno("If the child is a StatefulController then this should be True"):
     AStateful = bool
 
@@ -107,7 +108,7 @@ class ChildPart(Part):
         self,
         name: APartName,
         mri: AMri,
-        initial_visibility: AInitialVisibility = False,
+        initial_visibility: UInitialVisibility = None,
         stateful: AStateful = True,
     ) -> None:
         # For docs: after ChildPart init
@@ -116,7 +117,7 @@ class ChildPart(Part):
         self.mri = mri
         self.x: float = 0.0
         self.y: float = 0.0
-        self.visible: bool = initial_visibility
+        self.visible: Optional[bool] = initial_visibility
         # {part_name: visible} saying whether part_name is visible
         self.part_visibility: Dict[str, bool] = {}
         # {attr_name: attr_value} of last saved/loaded structure
@@ -201,6 +202,7 @@ class ChildPart(Part):
         # If not specified then take our own visibility from this same dict
         if self.visible is None:
             self.visible = self.part_visibility.get(self.name, False)
+        assert self.visible is not None
         ret = LayoutInfo(mri=self.mri, x=self.x, y=self.y, visible=self.visible)
         return [ret]
 

--- a/tests/test_modules/test_builtin/test_childpart.py
+++ b/tests/test_modules/test_builtin/test_childpart.py
@@ -45,7 +45,6 @@ class TestChildPart(unittest.TestCase):
             mri=block_mri,
             name="part%s" % block_mri,
             stateful=False,
-            initial_visibility=True,
         )
         self.p.add_controller(controller)
         return part, controller
@@ -106,6 +105,7 @@ class TestChildPart(unittest.TestCase):
         assert info_out.name == "sourceportConnector"
         assert info_out.port == Port.INT32
         assert info_out.connected_value == "Connector1"
+        assert self.c.block_view().layout.value.visible == [True, True, True]
 
     def test_layout(self):
         b = self.p.block_view("mainBlock")

--- a/tests/test_modules/test_builtin/test_childpart.py
+++ b/tests/test_modules/test_builtin/test_childpart.py
@@ -1,6 +1,5 @@
 import shutil
 import unittest
-from unittest.mock import MagicMock
 
 from malcolm.core import (
     Context,
@@ -155,37 +154,3 @@ class TestChildPart(unittest.TestCase):
         assert structure2 == expected
         self.p1.on_load(context, dict(sinkportConnector="blah_again"))
         assert b1.sinkportConnector.value == "blah_again"
-
-    def test_on_layout_first_call_sets_part_visibility_to_False(self):
-        new_part = ChildPart("new_part", "NEW:PART:MRI")
-        context_mock = MagicMock(name="mock_context")
-        ports_mock = MagicMock(name="mock_ports")
-        layout_mock = MagicMock(name="mock_layout")
-        new_part.calculate_part_visibility = MagicMock(name="mock_calculate_visibility")
-
-        assert not new_part.part_visibility
-        assert not new_part.visible
-
-        returned_layout = new_part.on_layout(context_mock, ports_mock, layout_mock)
-
-        assert new_part.visible is False
-        assert new_part.calculate_part_visibility.called_once_with(ports_mock)
-        assert returned_layout[0].mri == "NEW:PART:MRI"
-        assert returned_layout[0].visible is False
-
-    def test_on_layout_first_call_keeps_part_visibility_to_True(self):
-        new_part = ChildPart("new_part", "NEW:PART:MRI", initial_visibility=True)
-        context_mock = MagicMock(name="mock_context")
-        ports_mock = MagicMock(name="mock_ports")
-        layout_mock = MagicMock(name="mock_layout")
-        new_part.calculate_part_visibility = MagicMock(name="mock_calculate_visibility")
-
-        assert not new_part.part_visibility
-        assert new_part.visible is True
-
-        returned_layout = new_part.on_layout(context_mock, ports_mock, layout_mock)
-
-        assert new_part.visible is True
-        assert new_part.calculate_part_visibility.called_once_with(ports_mock)
-        assert returned_layout[0].mri == "NEW:PART:MRI"
-        assert returned_layout[0].visible is True

--- a/tests/test_modules/test_builtin/test_childpart.py
+++ b/tests/test_modules/test_builtin/test_childpart.py
@@ -1,5 +1,6 @@
 import shutil
 import unittest
+from unittest.mock import MagicMock
 
 from malcolm.core import (
     Context,
@@ -154,3 +155,37 @@ class TestChildPart(unittest.TestCase):
         assert structure2 == expected
         self.p1.on_load(context, dict(sinkportConnector="blah_again"))
         assert b1.sinkportConnector.value == "blah_again"
+
+    def test_on_layout_first_call_sets_part_visibility_to_False(self):
+        new_part = ChildPart("new_part", "NEW:PART:MRI")
+        context_mock = MagicMock(name="mock_context")
+        ports_mock = MagicMock(name="mock_ports")
+        layout_mock = MagicMock(name="mock_layout")
+        new_part.calculate_part_visibility = MagicMock(name="mock_calculate_visibility")
+
+        assert not new_part.part_visibility
+        assert not new_part.visible
+
+        returned_layout = new_part.on_layout(context_mock, ports_mock, layout_mock)
+
+        assert new_part.visible is False
+        assert new_part.calculate_part_visibility.called_once_with(ports_mock)
+        assert returned_layout[0].mri == "NEW:PART:MRI"
+        assert returned_layout[0].visible is False
+
+    def test_on_layout_first_call_keeps_part_visibility_to_True(self):
+        new_part = ChildPart("new_part", "NEW:PART:MRI", initial_visibility=True)
+        context_mock = MagicMock(name="mock_context")
+        ports_mock = MagicMock(name="mock_ports")
+        layout_mock = MagicMock(name="mock_layout")
+        new_part.calculate_part_visibility = MagicMock(name="mock_calculate_visibility")
+
+        assert not new_part.part_visibility
+        assert new_part.visible is True
+
+        returned_layout = new_part.on_layout(context_mock, ports_mock, layout_mock)
+
+        assert new_part.visible is True
+        assert new_part.calculate_part_visibility.called_once_with(ports_mock)
+        assert returned_layout[0].mri == "NEW:PART:MRI"
+        assert returned_layout[0].visible is True


### PR DESCRIPTION
This means "True if the child Block is connected to anything"