### PR TITLE
Fix/hardware trigger breakpoints

### DIFF
--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -367,8 +367,30 @@ class DetectorDriverPart(builtin.parts.ChildPart):
         )
 
     @add_call_types
-    def on_post_run_armed(self, steps_to_do: scanning.hooks.AStepsToDo) -> None:
-        if self.is_hardware_triggered:
+    def on_post_run_armed(
+        self,
+        context: scanning.hooks.AContext,
+        completed_steps: scanning.hooks.ACompletedSteps,
+        steps_to_do: scanning.hooks.AStepsToDo,
+        part_info: scanning.hooks.APartInfo,
+        generator: scanning.hooks.AGenerator,
+        breakpoints: scanning.controllers.ABreakpoints = None,
+    ) -> None:
+        if breakpoints:
+            # We may have a different number of steps each time
+            self.setup_detector(
+                context,
+                completed_steps,
+                steps_to_do,
+                steps_to_do,
+                generator.duration,
+                part_info,
+            )
+            if self.is_hardware_triggered:
+                # We can now re-arm hardware-triggered detectors
+                self.arm_detector(context)
+        elif self.is_hardware_triggered:
+            # Otherwise for hardware detectors just update done_when_reaches
             self.done_when_reaches += steps_to_do
 
     @add_call_types

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -293,6 +293,7 @@ class DetectorDriverPart(builtin.parts.ChildPart):
         part_info: scanning.hooks.APartInfo,
         generator: scanning.hooks.AGenerator,
         fileDir: scanning.hooks.AFileDir,
+        breakpoints: scanning.controllers.ABreakpoints,
         **kwargs: Any,
     ) -> None:
         context.unsubscribe_all()
@@ -313,10 +314,10 @@ class DetectorDriverPart(builtin.parts.ChildPart):
             mode = child.triggerMode.value
             self.is_hardware_triggered = mode not in self.soft_trigger_modes
 
-        # If detector is hardware triggered we can configure the detector for all frames
-        # now, rather than configuring and arming for each inner scan, and send the
-        # triggers for one inner scan in each run
-        if self.is_hardware_triggered:
+        # If detector is hardware triggered, and we aren't using breakpoints, we can
+        # configure the detector for all frames now, rather than configuring and arming
+        # for each inner scan, and send the triggers for one inner scan in each run
+        if self.is_hardware_triggered and not breakpoints:
             num_images = generator.size - completed_steps
         else:
             num_images = steps_to_do

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -293,7 +293,7 @@ class DetectorDriverPart(builtin.parts.ChildPart):
         part_info: scanning.hooks.APartInfo,
         generator: scanning.hooks.AGenerator,
         fileDir: scanning.hooks.AFileDir,
-        breakpoints: scanning.controllers.ABreakpoints,
+        breakpoints: scanning.controllers.ABreakpoints = None,
         **kwargs: Any,
     ) -> None:
         context.unsubscribe_all()

--- a/malcolm/modules/ADCore/parts/detectordriverpart.py
+++ b/malcolm/modules/ADCore/parts/detectordriverpart.py
@@ -315,8 +315,8 @@ class DetectorDriverPart(builtin.parts.ChildPart):
             self.is_hardware_triggered = mode not in self.soft_trigger_modes
 
         # If detector is hardware triggered, and we aren't using breakpoints, we can
-        # configure the detector for all frames now, rather than configuring and arming
-        # for each inner scan, and send the triggers for one inner scan in each run
+        # configure the detector for all frames now. This is instead of configuring and
+        # arming the detector for each inner scan, so we save some time
         if self.is_hardware_triggered and not breakpoints:
             num_images = generator.size - completed_steps
         else:

--- a/malcolm/modules/scanning/controllers/__init__.py
+++ b/malcolm/modules/scanning/controllers/__init__.py
@@ -2,6 +2,7 @@
 from malcolm.core import submodule_all
 
 from .runnablecontroller import (
+    ABreakpoints,
     AConfigDir,
     AConfigureParams,
     ADescription,


### PR DESCRIPTION
The changes with arming a hardware-triggered detector for all points even with outer axes seems to break the breakpoints interface, at least for start of row triggering.

It also breaks software-triggered detectors as it makes the assumption that each breakpoint is after the same number of steps.

These changes revert the behaviour back to breaking down the scan into chunks when breakpoints are included, but should hopefully leave the behaviour untouched where breakpoints aren't provided.