### PR TITLE
Use servo frequency PV instead of I10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_ after 2-1.
 
+`4.6`_
+--------------------------
+
+Fixed:
+- Servo interrupt frequency getter for PowerPMAC (needed at scan
+  configuring phase), this requires pmac version 2-5-5 or higher
+
 `4.5`_ - 2021-04-27
 --------------------------
 

--- a/malcolm/modules/pmac/blocks/pmac_status_block.yaml
+++ b/malcolm/modules/pmac/blocks/pmac_status_block.yaml
@@ -15,10 +15,10 @@
     rbv: $(pv_prefix):Port
     port_type: motor
 
-- ca.parts.CALongPart:
-    name: i10
-    description: Value of i10 (servo ticks)
-    rbv: $(pv_prefix):I10
+- ca.parts.CADoublePart:
+    name: servoFreq
+    description: Servo interrupt frequency (hz)
+    rbv: $(pv_prefix):SERVO_FREQ
 
 - ca.parts.CACharArrayPart:
     name: iVariables

--- a/malcolm/modules/pmac/parts/pmacstatuspart.py
+++ b/malcolm/modules/pmac/parts/pmacstatuspart.py
@@ -21,9 +21,7 @@ class PmacStatusPart(builtin.parts.ChildPart):
 
     @add_call_types
     def servo_frequency(self, context: builtin.hooks.AContext) -> AServoFrequency:
-        child = context.block_view(self.mri)
-        freq = 8388608000.0 / child.i10.value
-        return freq
+        return context.block_view(self.mri).servoFreq.value
 
     @add_call_types
     def report_status(self, context: scanning.hooks.AContext) -> scanning.hooks.UInfos:

--- a/tests/test_modules/test_pmac/test_pmacstatuspart.py
+++ b/tests/test_modules/test_pmac/test_pmacstatuspart.py
@@ -11,7 +11,7 @@ class TestPmacStatusPart(ChildTestCase):
         child = self.create_child_block(
             pmac_status_block, self.process, mri="my_mri", pv_prefix="PV:PRE"
         )
-        self.set_attributes(child, i10=1705244)
+        self.set_attributes(child, servoFreq=2500.04)
         c = ManagerController("PMAC", "/tmp", use_git=False)
         self.o = PmacStatusPart(name="part", mri="my_mri", initial_visibility=True)
         c.add_part(self.o)
@@ -24,4 +24,4 @@ class TestPmacStatusPart(ChildTestCase):
 
     def test_servo_freq(self):
         freq = self.b.servoFrequency()
-        assert freq == 4919.300698316487
+        assert freq == 2500.04


### PR DESCRIPTION
This way, the PmacStatusPart will also work for PowerPMAC (this also depends on https://github.com/dls-controls/pmac/pull/91)