### PR TITLE
Remove rank padding on secondary and attribute datasets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,19 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_ after 2-1.
 
+`5.4`_ - 2022-03-30
+-------------------
+
+Changed:
+
+- Removed rank padding on secondary and attribute datasets. Before this change,
+  AreaDetector drivers using the HDF5 file writer would pad these data with an
+  additional 1x1 dimension on top of the scan shape. This makes it simpler for
+  plotting and visualisation. This change requires a minimum ADCore version of
+  3.12 for the HDF5 file writing plugins.
+
 `5.3`_ - 2022-03-18
-----------
+-------------------
 
 Changed:
 
@@ -756,6 +767,7 @@ Added:
 
 - Initial release with hello world and websocket comms
 
+.. _5.4: https://github.com/dls-controls/pymalcolm/compare/5.3...5.4
 .. _5.3: https://github.com/dls-controls/pymalcolm/compare/5.2...5.3
 .. _5.2: https://github.com/dls-controls/pymalcolm/compare/5.1...5.2
 .. _5.1: https://github.com/dls-controls/pymalcolm/compare/5.0...5.1

--- a/malcolm/modules/ADAndor/parts/andordriverpart.py
+++ b/malcolm/modules/ADAndor/parts/andordriverpart.py
@@ -92,7 +92,9 @@ class AndorDriverPart(ADCore.parts.DetectorDriverPart):
                 return None
         # Otherwise just let the DetectorDriverPart validate for us
         else:
-            return super().on_validate(context, generator, frames_per_step=frames_per_step)
+            return super().on_validate(
+                context, generator, frames_per_step=frames_per_step
+            )
 
     def setup_detector(
         self,

--- a/malcolm/modules/ADAndor/parts/andordriverpart.py
+++ b/malcolm/modules/ADAndor/parts/andordriverpart.py
@@ -92,7 +92,7 @@ class AndorDriverPart(ADCore.parts.DetectorDriverPart):
                 return None
         # Otherwise just let the DetectorDriverPart validate for us
         else:
-            return super().on_validate(generator, frames_per_step=frames_per_step)
+            return super().on_validate(context, generator, frames_per_step=frames_per_step)
 
     def setup_detector(
         self,

--- a/malcolm/modules/ADCore/includes/adbase_parts.yaml
+++ b/malcolm/modules/ADCore/includes/adbase_parts.yaml
@@ -74,8 +74,3 @@
       name: arraySizeY
       description: height of the image in pixels
       rbv: $(prefix):ArraySizeY_RBV
-
-- ca.parts.CAStringPart:
-    name: driverVersion
-    description: Version of EPICS AD Driver
-    rbv: $(prefix):DriverVersion_RBV

--- a/malcolm/modules/ADCore/includes/filewriting_collection.yaml
+++ b/malcolm/modules/ADCore/includes/filewriting_collection.yaml
@@ -30,3 +30,4 @@
     name: HDF5
     mri: $(mri_prefix):HDF5
     runs_on_windows: $(runs_on_windows)
+    required_version: 3.12

--- a/malcolm/modules/ADCore/includes/ndarraybase_parts.yaml
+++ b/malcolm/modules/ADCore/includes/ndarraybase_parts.yaml
@@ -34,3 +34,8 @@
     name: attributesFile
     description: Filename for NDAttributes
     pv: $(prefix):NDAttributesFile
+
+- ca.parts.CAStringPart:
+    name: driverVersion
+    description: Version of EPICS AD Driver
+    rbv: $(prefix):DriverVersion_RBV

--- a/malcolm/modules/ADCore/parts/hdfwriterpart.py
+++ b/malcolm/modules/ADCore/parts/hdfwriterpart.py
@@ -88,7 +88,7 @@ def create_dataset_infos(
                 name="%s.%s" % (name, calculated_info.name),
                 filename=filename,
                 type=scanning.util.DatasetType.SECONDARY,
-                rank=detector_rank + generator_rank,
+                rank=generator_rank,
                 path="/entry/%s/%s" % (calculated_info.name, calculated_info.name),
                 uniqueid=uniqueid,
             )
@@ -103,7 +103,7 @@ def create_dataset_infos(
             filename=filename,
             type=dataset_info.type,
             # All attributes share the same rank as the detector image
-            rank=detector_rank + generator_rank,
+            rank=generator_rank,
             path=f"/entry/{dataset_info.name}/{dataset_info.name}",
             uniqueid=uniqueid,
         )

--- a/tests/test_modules/test_ADAndor/test_andordriverpart.py
+++ b/tests/test_modules/test_ADAndor/test_andordriverpart.py
@@ -353,8 +353,8 @@ class TestAndorDetectorDriverPart(ChildTestCase):
             AssertionError, self.andor_driver_part.on_validate, self.context, generator
         )
 
-    @patch("malcolm.modules.ADCore.parts.DetectorDriverPart.on_validate")
-    def test_validate_calls_parent_method(self, mock_super_validate):
+    @patch("malcolm.modules.ADCore.parts.DetectorDriverPart.on_validate", autospec=True)
+    def test_validate_succeeds_via_parent_method(self, mock_super_validate):
         generator = self._get_static_generator(5.0)
         generator_zero_duration = self._get_static_generator(0.0)
 
@@ -369,10 +369,20 @@ class TestAndorDetectorDriverPart(ChildTestCase):
 
         # Check the mock method was called with the correct args
         expected_calls = [
-            call(generator, frames_per_step=1),
-            call(generator, frames_per_step=2),
-            call(generator_zero_duration, frames_per_step=1),
-            call(generator_zero_duration, frames_per_step=2),
+            call(self.andor_driver_part, self.context, generator, frames_per_step=1),
+            call(self.andor_driver_part, self.context, generator, frames_per_step=2),
+            call(
+                self.andor_driver_part,
+                self.context,
+                generator_zero_duration,
+                frames_per_step=1,
+            ),
+            call(
+                self.andor_driver_part,
+                self.context,
+                generator_zero_duration,
+                frames_per_step=2,
+            ),
         ]
         mock_super_validate.assert_has_calls(expected_calls)
 

--- a/tests/test_modules/test_ADCore/test_hdfwriterpart.py
+++ b/tests/test_modules/test_ADCore/test_hdfwriterpart.py
@@ -211,28 +211,28 @@ class TestHDFWriterPart(ChildTestCase):
         assert infos[1].name == "xspress3.sum"
         assert infos[1].filename == "thing-xspress3.h5"
         assert infos[1].type == DatasetType.SECONDARY
-        assert infos[1].rank == 4
+        assert infos[1].rank == 2
         assert infos[1].path == "/entry/sum/sum"
         assert infos[1].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
 
         assert infos[2].name == "I0.data"
         assert infos[2].filename == "thing-xspress3.h5"
         assert infos[2].type == DatasetType.PRIMARY
-        assert infos[2].rank == 4
+        assert infos[2].rank == 2
         assert infos[2].path == "/entry/I0.data/I0.data"
         assert infos[2].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
 
         assert infos[3].name == "It.data"
         assert infos[3].filename == "thing-xspress3.h5"
         assert infos[3].type == DatasetType.MONITOR
-        assert infos[3].rank == 4
+        assert infos[3].rank == 2
         assert infos[3].path == "/entry/It.data/It.data"
         assert infos[3].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
 
         assert infos[4].name == "t1x.value"
         assert infos[4].filename == "thing-xspress3.h5"
         assert infos[4].type == DatasetType.POSITION_VALUE
-        assert infos[4].rank == 4
+        assert infos[4].rank == 2
         assert infos[4].path == "/entry/t1x.value/t1x.value"
         assert infos[4].uniqueid == "/entry/NDAttributes/NDArrayUniqueId"
 

--- a/tests/test_modules/test_ADCore/test_hdfwriterpart.py
+++ b/tests/test_modules/test_ADCore/test_hdfwriterpart.py
@@ -163,6 +163,24 @@ class TestHDFWriterPart(ChildTestCase):
             "fileTemplate",
         ]
 
+    @patch("malcolm.modules.ADCore.parts.hdfwriterpart.check_driver_version")
+    def test_validate(self, check_mock):
+        self.o = HDFWriterPart(name="m", mri="BLOCK:HDF5")
+
+        # Version check should not be called with require_version None
+        self.o.require_version = None
+        self.set_attributes(self.child, driverVersion="1.1")
+
+        self.o.on_validate(self.context)
+
+        check_mock.assert_not_called()
+
+        # Test version check called if required_version not None
+        self.o.required_version = "1.0"
+        self.o.on_validate(self.context)
+
+        check_mock.assert_called_once_with("1.1", "1.0")
+
     def configure_and_check_output(self, on_windows=False):
         energy = LineGenerator("energy", "kEv", 13.0, 15.2, 2)
         spiral = SpiralGenerator(["x", "y"], ["mm", "mm"], [0.0, 0.0], 5.0, scale=2.0)

--- a/tests/test_modules/test_ADCore/test_util.py
+++ b/tests/test_modules/test_ADCore/test_util.py
@@ -1,6 +1,7 @@
 import unittest
 
-from malcolm.modules.ADCore.util import make_xml_filename
+from malcolm.core import IncompatibleError
+from malcolm.modules.ADCore.util import check_driver_version, make_xml_filename
 
 
 class TestMakeXmlFilename(unittest.TestCase):
@@ -31,3 +32,19 @@ class TestMakeXmlFilename(unittest.TestCase):
         actual_filename = make_xml_filename(file_dir, mri)
 
         self.assertEqual(expected_filename, actual_filename)
+
+
+class TestCheckDriverVersion(unittest.TestCase):
+    def test_version_check(self):
+        required_version = "2.2"
+        self.assertRaises(
+            IncompatibleError, check_driver_version, "1.9", required_version
+        )
+        self.assertRaises(
+            IncompatibleError, check_driver_version, "2.1", required_version
+        )
+        self.assertRaises(
+            IncompatibleError, check_driver_version, "3.0", required_version
+        )
+        check_driver_version("2.2", required_version)
+        check_driver_version("2.2.3", required_version)


### PR DESCRIPTION
This makes it possible to plot with these datasets on the x axis. Requires [ADCore#474](https://github.com/areaDetector/ADCore/pull/474)