### PR TITLE
Fix/ip validation

### DIFF
--- a/malcolm/modules/web/parts/websocketserverpart.py
+++ b/malcolm/modules/web/parts/websocketserverpart.py
@@ -189,13 +189,22 @@ class WebsocketServerPart(Part):
     def on_report_handlers(self) -> UHandlerInfos:
         validators = []
         if self.subnet_validation:
-            # Create an ip validator for every interface that is up
+            # Try creating an ip validator for every interface that is up
             for ifname in os.listdir(SYSNET):
                 with open(os.path.join(SYSNET, ifname, "operstate")) as f:
                     state = str(f.read())
                 if state != "down\n":
                     # interface is up
-                    validators.append(get_ip_validator(ifname))
+                    try:
+                        validators.append(get_ip_validator(ifname))
+                    except OSError as exception_message:
+                        # Ignore any interfaces that fail
+                        print(
+                            f"{self.name} - failed to create IP validator for {ifname}"
+                            f" (skipping): {exception_message}"
+                        )
+            # Check we have at least one created validator
+            assert len(validators) > 0, "Failed to create any IP validators!"
         info = HandlerInfo(
             r"/%s" % self.name,
             MalcWebSocketHandler,

--- a/malcolm/modules/web/parts/websocketserverpart.py
+++ b/malcolm/modules/web/parts/websocketserverpart.py
@@ -185,16 +185,22 @@ class WebsocketServerPart(Part):
         # Hooks
         registrar.hook(ReportHandlersHook, self.on_report_handlers)
 
+    @staticmethod
+    def is_interface_up(ifname: str) -> bool:
+        with open(os.path.join(SYSNET, ifname, "operstate")) as f:
+            state = str(f.read())
+        if state != "down\n":
+            return True
+        else:
+            return False
+
     @add_call_types
     def on_report_handlers(self) -> UHandlerInfos:
         validators = []
         if self.subnet_validation:
             # Try creating an ip validator for every interface that is up
             for ifname in os.listdir(SYSNET):
-                with open(os.path.join(SYSNET, ifname, "operstate")) as f:
-                    state = str(f.read())
-                if state != "down\n":
-                    # interface is up
+                if self.is_interface_up(ifname):
                     try:
                         validators.append(get_ip_validator(ifname))
                     except OSError as exception_message:
@@ -205,8 +211,9 @@ class WebsocketServerPart(Part):
                         )
             # Check we have at least one created validator
             assert len(validators) > 0, "Failed to create any IP validators!"
+
         info = HandlerInfo(
-            r"/%s" % self.name,
+            f"/{self.name}",
             MalcWebSocketHandler,
             registrar=self.registrar,
             validators=validators,

--- a/tests/test_modules/test_web/test_websocketserverpart.py
+++ b/tests/test_modules/test_web/test_websocketserverpart.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from mock import patch
+
+from malcolm.modules.web.parts import WebsocketServerPart
+
+
+@patch("malcolm.modules.web.parts.websocketserverpart.get_ip_validator")
+@patch.object(WebsocketServerPart, "is_interface_up")
+@patch.object(os, "listdir")
+class TestWebsocketServerPart(unittest.TestCase):
+    def test_on_report_handlers_with_subnet_validation_succeeds_for_one_good_interface(
+        self, mock_os_listdir, mock_is_interface_up, mock_get_ip_validator
+    ):
+        # Return our fake interfaces
+        mock_os_listdir.return_value = ["interface_1", "interface_2", "interface_3"]
+        # The state of the interfaces - 2 are "up"
+        mock_is_interface_up.side_effect = [True, False, True]
+        # Return a pretend validator and one error
+        mock_get_ip_validator.side_effect = ["validator_1", OSError()]
+
+        websocket_server_part = WebsocketServerPart()
+
+        info = websocket_server_part.on_report_handlers()
+
+        # We should only have one validator
+        assert info.kwargs["validators"] == ["validator_1"]
+
+    def test_on_report_handlers_fails_with_subnet_validation_with_no_good_interfaces(
+        self, mock_os_listdir, mock_is_interface_up, mock_get_ip_validator
+    ):
+        # Return our fake interfaces
+        mock_os_listdir.return_value = ["interface_1", "interface_2", "interface_3"]
+        # The state of the interfaces
+        mock_is_interface_up.side_effect = [False, False, True]
+        # Pretend validators
+        mock_get_ip_validator.side_effect = [OSError()]
+
+        websocket_server_part = WebsocketServerPart()
+
+        self.assertRaises(AssertionError, websocket_server_part.on_report_handlers)


### PR DESCRIPTION
Currently the WebsocketServerPart falls over with subnet validation if the fcntl.ioctl() call for any up interfaces. This has been observed on happen on p45-control which has virtual interfaces present.

This changes that behaviour so it ignores failures so long as at least one validator is successfully created.