### PR TITLE
Add min_acquire_period to DetectorDriverPart

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_ after 2-1.
 
+Unreleased
+----------
+
+Added:
+
+- DetectorDriverPart now has optional min_acquire_period argument. When set to a
+  non-zero value this is checked during validation against the generator
+  duration to ensure the detector can keep up during the acquisition.
+
 `4.6`_ - 2021-08-17
 -------------------
 

--- a/malcolm/modules/ADPilatus/blocks/ADPilatus_runnable_block.yaml
+++ b/malcolm/modules/ADPilatus/blocks/ADPilatus_runnable_block.yaml
@@ -10,6 +10,11 @@
     name: config_dir
     description: Where to store saved configs
 
+- builtin.parameters.float64:
+    name: min_acquire_period
+    description: Minimum acquire period for detector
+    default: 0.0  # Always pass validation
+
 - scanning.controllers.RunnableController:
     mri: $(mri_prefix)
     config_dir: $(config_dir)
@@ -21,10 +26,11 @@
 - ADCore.parts.DetectorDriverPart:
     name: Pilatus
     mri: $(mri_prefix):DRV
+    min_acquire_period: $(min_acquire_period)
 
 - scanning.parts.ExposureDeadtimePart:
     name: DEADTIME
-    initial_readout_time: 1e-3 
+    initial_readout_time: 1e-3
 
 - ADCore.blocks.stats_plugin_block:
     mri: $(mri_prefix):STAT

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -171,6 +171,9 @@ class PmacChildPart(builtin.parts.ChildPart):
         # back to duration
         duration = 2 * float(micros) / 1e6
         if duration != generator.duration:
+            self.log.debug(
+                f"Calculated duration {duration} does not match {generator}"
+            )
             serialized = generator.to_dict()
             new_generator = CompoundGenerator.from_dict(serialized)
             new_generator.duration = duration

--- a/malcolm/modules/scanning/controllers/runnablecontroller.py
+++ b/malcolm/modules/scanning/controllers/runnablecontroller.py
@@ -395,7 +395,7 @@ class RunnableController(builtin.controllers.ManagerController):
                         tweak.parameter
                     ].validate(tweak.value)
                     setattr(params, tweak.parameter, deserialized)
-                    self.log.debug("Tweaking {tweak.parameter} to {deserialized}")
+                    self.log.debug(f"Tweaking {tweak.parameter} to {deserialized}")
             else:
                 # Consistent set, just return the params
                 return params


### PR DESCRIPTION
This allows defining of a minimum acheivable acquire period for a detector in the top level yaml config

Outstanding points:
- I think the way I have updated the `ADPilatus_runnable_block` to take `min_acquire_period` and pass it through to `Detector DriverPart` means we now have to define it in the top level yaml config - is there a way to make this optional or have a sensible default (does it support, e.g., `min_acquire_period: $(min_acquire_period=0.002)`)?