### PR TITLE
Fix/xmap energy setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Added:
   non-zero value this is checked during validation against the generator
   duration to ensure the detector can keep up during the acquisition.
 
+Fixed
+
+- Malcolm designs will no longer overwrite XMAP energy values
+
 `4.6`_ - 2021-08-17
 -------------------
 

--- a/malcolm/modules/xmap/blocks/xmap_driver_block.yaml
+++ b/malcolm/modules/xmap/blocks/xmap_driver_block.yaml
@@ -87,24 +87,28 @@
     description: MCA Max Energy
     pv: $(prefix):DXP1:MaxEnergy
     rbv_suffix: _RBV
+    config: false
 
 - ca.parts.CADoublePart:
     name: dxp2MaxEnergy
     description: MCA Max Energy
     pv: $(prefix):DXP2:MaxEnergy
     rbv_suffix: _RBV
+    config: false
 
 - ca.parts.CADoublePart:
     name: dxp3MaxEnergy
     description: MCA Max Energy
     pv: $(prefix):DXP3:MaxEnergy
     rbv_suffix: _RBV
+    config: false
 
 - ca.parts.CADoublePart:
     name: dxp4MaxEnergy
     description: MCA Max Energy
     pv: $(prefix):DXP4:MaxEnergy
     rbv_suffix: _RBV
+    config: false    
 
 - ca.parts.CALongPart:
     name: pixelsPerBuffer


### PR DESCRIPTION
These changes will stop the Malcolm design from overwriting the energy values for xmaps.