### PR TITLE
Fix/move pre run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Added:
 Fixed
 
 - Malcolm designs will no longer overwrite XMAP energy values
+- The PreRunHook will now run at the beginning of do_run() so that it also runs
+  on a resume.
 
 `4.6`_ - 2021-08-17
 -------------------

--- a/malcolm/modules/scanning/controllers/runnablecontroller.py
+++ b/malcolm/modules/scanning/controllers/runnablecontroller.py
@@ -512,10 +512,6 @@ class RunnableController(builtin.controllers.ManagerController):
         Disabled state.
         """
 
-        # Run all PreRunHooks
-        hook = PreRunHook
-        self.do_pre_run(hook)
-
         if self.configured_steps.value < self.total_steps.value:
             next_state = ss.ARMED
         else:
@@ -548,10 +544,12 @@ class RunnableController(builtin.controllers.ManagerController):
             self.go_to_error_state(e)
             raise
 
-    def do_pre_run(self, hook: Type[ControllerHook]) -> None:
-        self.run_hooks(hook(p, c) for p, c in self.part_contexts.items())
+    def do_run(self, hook):
+        # type: (Type[ControllerHook]) -> None
 
-    def do_run(self, hook: Type[ControllerHook]) -> None:
+        # Run all PreRunHooks
+        self.run_hooks(PreRunHook(p, c) for p, c in self.part_contexts.items())
+
         self.run_hooks(hook(p, c) for p, c in self.part_contexts.items())
         self.abortable_transition(ss.POSTRUN)
         completed_steps = self.configured_steps.value


### PR DESCRIPTION
Moved the preRunHook so that it is at the start of do_run(). This means that it would run on a resume.

This had previously affected J08 as they have a shutter using the AttributePreRunPart, which meant that on a resume the shutter would not reopen after a pause. 