### PR TITLE
PmacChildPart now only reports progress for every point trigger mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_ after 2-1.
 
+Unreleased
+----------
+
+Fixed:
+
+- PmacChildPart now only reports progress if the brick is providing a trigger
+  at every point. This means the scan block's RunnableController should now
+  report more useful progress for scans using start of row triggering or
+  position compare.
+
 `5.0`_ - 2021-11-30
 -------------------
 
@@ -24,7 +34,8 @@ Changed:
     - "readoutTime": 0.005,
     - "frequencyAccuracy": 50.0
 
-  You can then set the readout time when you instantiate the runnable block (frequency accuracy is probably fine at the default value of 50.0):
+  You can then set the readout time when you instantiate the runnable block
+  (frequency accuracy is probably fine at the default value of 50.0):
 
   .. code-block:: yaml
 

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -433,7 +433,9 @@ class PmacChildPart(builtin.parts.ChildPart):
         # scan step
         if scanned > 0:
             completed_steps = self.completed_steps_lookup[scanned - 1]
-            self.registrar.report(scanning.infos.RunProgressInfo(completed_steps))
+            # Only report progress if we are triggering for every point
+            if self.output_triggers == scanning.infos.MotionTrigger.EVERY_POINT:
+                self.registrar.report(scanning.infos.RunProgressInfo(completed_steps))
             # Keep PROFILE_POINTS trajectory points in front
             if (
                 not self.loading

--- a/tests/test_modules/test_pmac/test_pmacchildpart.py
+++ b/tests/test_modules/test_pmac/test_pmacchildpart.py
@@ -9,6 +9,7 @@ from mock import ANY, Mock, call, patch
 from scanpointgenerator import CompoundGenerator, LineGenerator, StaticPointGenerator
 
 from malcolm.core import Context, Process
+from malcolm.modules import scanning
 from malcolm.modules.builtin.defines import tmp_dir
 from malcolm.modules.pmac.parts import PmacChildPart
 from malcolm.modules.scanning.infos import (
@@ -705,6 +706,21 @@ class TestPMACChildPart(ChildTestCase):
         assert self.o.end_index == 3
         assert len(self.o.completed_steps_lookup) == 11
         assert len(self.o.profile["timeArray"]) == 3
+
+    def test_update_step_does_not_report_when_trigger_not_every_point(self):
+        # Need to configure so we don't error
+        self.do_configure(axes_to_scan=[])
+        # Registrar mock to check we weren't called
+        self.o.registrar = Mock()
+
+        self.o.output_triggers == scanning.infos.MotionTrigger.NONE
+        self.o.update_step(1, self.context.block_view("PMAC"))
+
+        self.o.output_triggers == scanning.infos.MotionTrigger.ROW_GATE
+        self.o.update_step(2, self.context.block_view("PMAC"))
+
+        # Ensure the mock did not get called
+        self.o.registrar.assert_not_called()
 
     def test_run(self):
         self.o.generator = ANY


### PR DESCRIPTION
Currently the PmacChildPart reports the progress for start of row triggering. This can result in no updates until the end of the scan for Tomographies (i.e. a single motion axis) or slow updates for long rows.

This changes that behaviour so that progress shouldn't be reported unless the Pmac is providing a trigger at every point in the scan.