### PR TITLE
Fix/pmacchildpart profile refactor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_ after 2-1.
 Unreleased
 ----------
 
+Changed:
+
+- PmacChildPart's profile generation is now split into two methods based on the
+  trigger type. The loop performance has been improved, reducing configure
+  times by ~20% for small scans and ~40% for large scans when profile point
+  generation dominates. A Yield has also been added so the thread suspends
+  after each batch so it doesn't block other threads for the entire profile
+  calculation, which previously caused timeout problems with other components.
+
 Fixed:
 
 - PmacChildPart now only reports progress if the brick is providing a trigger

--- a/malcolm/modules/pmac/util.py
+++ b/malcolm/modules/pmac/util.py
@@ -158,6 +158,9 @@ def all_points_same_velocities(points: Points) -> Array[bool]:
         v2 = velocities[1:]
         results[axis_name] = np.isclose(v1, v2)
     result = and_all_axes(results)
+    # If we have no axes then all velocities are the same
+    if result is None:
+        result = np.ones(len(points), dtype=bool)
     return result
 
 
@@ -174,6 +177,9 @@ def all_points_joined(points: Points) -> Array[bool]:
         lowers = points.lower[axis_name][1:]
         results[axis_name] = np.logical_and(uppers == lowers, no_delay)
     result = and_all_axes(results)
+    # If we have no axes then all points are joined
+    if result is None:
+        result = np.ones(len(points), dtype=bool)
     return result
 
 


### PR DESCRIPTION
Refactored the profile generation method, now iterating through batches and splitting the method into two based on the type of motion trigger to reduce the number of checks.

Also added a yield after each batch so that we don't block other threads for the entire calculation, causing other parts to fail during configure from CA timeouts.

A couple of rough benchmarks on p45-ws001 for start of row triggering:

| Num points  | Configure time before | Configure time after |
| ---------------- | ----------------------------- | -------------------------- |
| 1,000,000 | 1.5s | 1.1s |
|  15,000,000 | 37s  | 22s |

This fixes #358 