### PR TITLE
Updated the template to fix bug where additional trigger can be sent

### DIFF
--- a/malcolm/modules/ADPandABlocks/blocks/panda_runnable_block_designs/template_double_seq_pcomp.json
+++ b/malcolm/modules/ADPandABlocks/blocks/panda_runnable_block_designs/template_double_seq_pcomp.json
@@ -161,7 +161,7 @@
       "inpaDelay": 0, 
       "inpb": "SEQ2.OUTA", 
       "inpbDelay": 0, 
-      "inpc": "ZERO", 
+      "inpc": "SRGATE2.OUT",
       "inpcDelay": 0, 
       "inpd": "ZERO", 
       "inpdDelay": 0, 
@@ -173,7 +173,7 @@
       "typec": "Input-Level", 
       "typed": "Input-Level", 
       "typee": "Input-Level", 
-      "func": "A|B", 
+      "func": "(A|B)&C",
       "outputs": "expanded"
     }, 
     "LUT5": {
@@ -183,7 +183,7 @@
       "inpaDelay": 0, 
       "inpb": "SEQ2.OUTB", 
       "inpbDelay": 0, 
-      "inpc": "ZERO", 
+      "inpc": "SRGATE2.OUT",
       "inpcDelay": 0, 
       "inpd": "ZERO", 
       "inpdDelay": 0, 
@@ -195,7 +195,7 @@
       "typec": "Input-Level", 
       "typed": "Input-Level", 
       "typee": "Input-Level", 
-      "func": "A|B", 
+      "func": "(A|B)&C",
       "outputs": "expanded"
     }, 
     "PCAP": {


### PR DESCRIPTION
There is a bug brought about by the recent double buffering changes which can cause an extra trigger to be sent at the end of an inner scan of a stack scan.

Between Scans in a stack, seqReset is called to reset the design and then it is re-configured. However there is an 8 clock tick delay on the signal coming into SeqB from SRGATE2.OUT where it will still be enabled, and if this lines up with the timing set in the Sequencer tables, a trigger can be sent at this time. In recent testing I have found a scan generator which will reproduce this.

This fix to the template design, and should be applied to existing PandA designs, means that although the Seq block can sill output a trigger the Live and Dead frame LUT blocks will only output a trigger while SRGATE2.OUT is high.