### PR TITLE
Add check of soft limit at start ramp and tail-off

### DIFF
--- a/malcolm/modules/pmac/includes/motor_records.yaml
+++ b/malcolm/modules/pmac/includes/motor_records.yaml
@@ -52,3 +52,13 @@
     name: userLowLimit
     description: User low limit
     rbv: $(pv_prefix).LLM
+
+- ca.parts.CADoublePart:
+    name: dialHighLimit
+    description: Dial high limit
+    rbv: $(pv_prefix).DHLM
+
+- ca.parts.CADoublePart:
+    name: dialLowLimit
+    description: Dial low limit
+    rbv: $(pv_prefix).DLLM

--- a/malcolm/modules/pmac/includes/motor_records.yaml
+++ b/malcolm/modules/pmac/includes/motor_records.yaml
@@ -42,3 +42,13 @@
     name: units
     description: Engineering units
     rbv: $(pv_prefix).EGU
+
+- ca.parts.CADoublePart:
+    name: userHighLimit
+    description: User high limit
+    rbv: $(pv_prefix).HLM
+
+- ca.parts.CADoublePart:
+    name: userLowLimit
+    description: User low limit
+    rbv: $(pv_prefix).LLM

--- a/malcolm/modules/pmac/parts/pmacchildpart.py
+++ b/malcolm/modules/pmac/parts/pmacchildpart.py
@@ -309,6 +309,12 @@ class PmacChildPart(builtin.parts.ChildPart):
                 0, velocity, min_ramp_time=MIN_TIME
             )
             start_pos = first_point.lower[axis_name] - acceleration_distance
+            assert (
+                motor_info.check_position_within_soft_limits(start_pos) is True
+            ), (
+                f"{motor_info.scannable}: ramp start position {start_pos} outside "
+                f"soft limits {motor_info.user_low_limit, motor_info.user_high_limit}"
+            )
             args[motor_info.cs_axis.lower()] = start_pos
             # Time profile that the move is likely to take
             # NOTE: this is only accurate if pmac max velocity in linear motion
@@ -967,7 +973,14 @@ class PmacChildPart(builtin.parts.ChildPart):
                 tail_off_time, motor_info.acceleration_time(0, velocity)
             )
             tail_off = motor_info.ramp_distance(velocity, 0)
-            axis_points[axis_name] = point.upper[axis_name] + tail_off
+            tail_off_pos = point.upper[axis_name] + tail_off
+            assert (
+                motor_info.check_position_within_soft_limits(tail_off_pos) is True
+            ), (
+                f"{motor_info.scannable}: tail off position {tail_off_pos} outside "
+                f"soft limits {motor_info.user_low_limit, motor_info.user_high_limit}"
+            )
+            axis_points[axis_name] = tail_off_pos
         # Do the last move
         user_program = self.get_user_program(PointType.TURNAROUND)
         self.add_profile_point(

--- a/malcolm/modules/pmac/util.py
+++ b/malcolm/modules/pmac/util.py
@@ -90,6 +90,8 @@ def cs_axis_mapping(
                 units=child.units.value,
                 user_high_limit=child.userHighLimit.value,
                 user_low_limit=child.userLowLimit.value,
+                dial_high_limit=child.dialHighLimit.value,
+                dial_low_limit=child.dialLowLimit.value,
             )
     missing = list(set(axes_to_move) - set(axis_mapping))
     assert not missing, "Some scannables %s are not in the CS mapping %s" % (

--- a/malcolm/modules/pmac/util.py
+++ b/malcolm/modules/pmac/util.py
@@ -88,6 +88,8 @@ def cs_axis_mapping(
                 scannable=name,
                 velocity_settle=child.velocitySettle.value,
                 units=child.units.value,
+                user_high_limit=child.userHighLimit.value,
+                user_low_limit=child.userLowLimit.value,
             )
     missing = list(set(axes_to_move) - set(axis_mapping))
     assert not missing, "Some scannables %s are not in the CS mapping %s" % (

--- a/malcolm/modules/system/controllers/ProcessController.py
+++ b/malcolm/modules/system/controllers/ProcessController.py
@@ -192,9 +192,7 @@ class ProcessController(builtin.controllers.ManagerController):
         # Run git command, don't care if it fails, logging the output
         cwd = kwargs.get("cwd", self.config_dir)
         try:
-            output = subprocess.check_output(
-                ("git",) + args, cwd=cwd
-            )
+            output = subprocess.check_output(("git",) + args, cwd=cwd)
         except subprocess.CalledProcessError as e:
             self.log.warning("Git command failed: %s\n%s", e, e.output)
             return None

--- a/tests/test_modules/test_pmac/test_motorinfo.py
+++ b/tests/test_modules/test_pmac/test_motorinfo.py
@@ -21,13 +21,14 @@ class TestMotorInfo(unittest.TestCase):
             units="mm",
             user_high_limit=100.0,
             user_low_limit=-100.0,
+            dial_high_limit=100.0,
+            dial_low_limit=-100.0,
         )
 
     def test_check_position_within_soft_limits_returns_True_for_disabled_limits(self):
         positions = [-25.0, 0.0, 1.35]
         # Disable soft limits
-        self.o.user_high_limit = 0.0
-        self.o.user_low_limit = 0.0
+        self.o.enable_soft_limits = False
 
         for position in positions:
             self.assertEqual(True, self.o.check_position_within_soft_limits(position))
@@ -90,6 +91,8 @@ class TestMotorPVT(unittest.TestCase):
             units="mm",
             user_high_limit=100.0,
             user_low_limit=-100.0,
+            dial_high_limit=100.0,
+            dial_low_limit=-100.0,
         )
 
     def check_distance(self, d, times, velocities):


### PR DESCRIPTION
This adds checks for soft limits in the pmacChildPart when calculating the move to the start position and the tail off at the end of a scan, and raises an Exception if they go out of bounds.

It is expected that GDA will do a basic check of the scan grid/line against the soft limits before submitting the scan to Malcolm.

The remaining edge cases are checking turnaround points and when fly scanning, which stretches out the points.

The other issues to potentially resolve are:

- Handling fly scans which stretch out the points
- Turnaround points
- Should the trajectory be aborted if running when attempting to add the tail off, or whether we can just get away with not adding the tail off point
