### PR TITLE
profile_between_points: round a very small distance to zero

### DIFF
--- a/malcolm/modules/pmac/util.py
+++ b/malcolm/modules/pmac/util.py
@@ -267,6 +267,9 @@ def profile_between_points(
     while iterations > 0:
         for axis_name, motor_info in axis_mapping.items():
             distance = next_point.lower[axis_name] - point.upper[axis_name]
+            # If the distance is tiny, round to zero
+            if np.isclose(distance, 0.0, atol=1e-12):
+                distance = 0.0
             p = motor_info.make_velocity_profile(
                 start_velocities[axis_name],
                 end_velocities[axis_name],

--- a/tests/test_modules/test_pmac/test_profile_between_points.py
+++ b/tests/test_modules/test_pmac/test_profile_between_points.py
@@ -1,0 +1,118 @@
+import unittest
+
+from scanpointgenerator import Point
+
+from malcolm.modules.pmac.infos import MotorInfo
+from malcolm.modules.pmac.util import profile_between_points
+
+
+class ProfileBetweenPoints(unittest.TestCase):
+    def setUp(self):
+        # Motor info and axis mappings from P99 sample stages
+        self.sample_x_motor_info = MotorInfo(
+            "X",
+            "BRICK1.CS1",
+            18.0,
+            -2e-05,
+            0.0,
+            1.8,
+            1.0,
+            "sample_x",
+            0.0,
+            "mm",
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        )
+        self.sample_y_motor_info = MotorInfo(
+            "Y",
+            "BRICK1.CS1",
+            18.0,
+            2e-05,
+            0.0,
+            1.8,
+            1.0,
+            "sample_y",
+            0.0,
+            "mm",
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        )
+        self.axis_mapping = {
+            "sample_x": self.sample_x_motor_info,
+            "sample_y": self.sample_y_motor_info,
+        }
+
+    def test_approximately_stationary_axis_results_in_2_profile_points(self):
+        # The stationary point which causes a problem on P99 testing
+        position = {"sample_y": 1.0000000000000888, "sample_x": 1.5}
+        point = Point()
+        point.lower = position
+        point.positions = position
+        point.upper = position
+        point.duration = 0.1
+
+        next_position = {"sample_y": 1.0000000000000666, "sample_x": 1.0}
+        next_point = Point()
+        next_point.lower = next_position
+        next_point.positions = next_position
+        next_point.upper = next_position
+        next_point.duration = 0.1
+
+        # Turnaround interval on P99
+        min_turnaround = 0.002
+        min_interval = 0.002
+
+        time_arrays, velocity_arrays = profile_between_points(
+            self.axis_mapping,
+            point,
+            next_point,
+            min_time=min_turnaround,
+            min_interval=min_interval,
+        )
+
+        expected_time_arrays = {
+            "sample_x": [0.0, 0.1, 0.284, 0.384],
+            "sample_y": [0.0, 0.384],
+        }
+        expected_velocity_arrays = {
+            "sample_x": [0.0, -1.760563380282, -1.760563380282, 0.0],
+            "sample_y": [0, 0],
+        }
+        self.assertEqual(time_arrays, expected_time_arrays)
+        self.assertEqual(velocity_arrays, expected_velocity_arrays)
+
+    def test_stationary_profile_is_two_points(self):
+        # Create the two points the same as each other
+        position = {"sample_y": 1.0, "sample_x": 1.5}
+        point = Point()
+        point.lower = position
+        point.positions = position
+        point.upper = position
+        point.duration = 0.1
+
+        # Turnaround interval on P99
+        min_turnaround = 0.002
+        min_interval = 0.002
+
+        time_arrays, velocity_arrays = profile_between_points(
+            self.axis_mapping,
+            point,
+            point,
+            min_time=min_turnaround,
+            min_interval=min_interval,
+        )
+
+        expected_time_arrays = {
+            "sample_x": [0.0, 0.002],
+            "sample_y": [0.0, 0.002],
+        }
+        expected_velocity_arrays = {
+            "sample_x": [0.0, 0.0],
+            "sample_y": [0.0, 0.0],
+        }
+        self.assertEqual(time_arrays, expected_time_arrays)
+        self.assertEqual(velocity_arrays, expected_velocity_arrays)


### PR DESCRIPTION
A generator describing a very small move of an axis over a line can result in the calculation of a profile with infinity or NaN positions in between points (i.e. turnarounds).

This is because profile_between_points creates a profile with 4 points with 2 pairs of 0 time intervals.

An example generator:
```
{
  typeid: 'scanpointgenerator:generator/CompoundGenerator:1.0',
  generators: [
    {
      typeid: 'scanpointgenerator:generator/LineGenerator:1.0',
      axes: [
        'sample_y'
      ],
      units: [
        'mm'
      ],
      start: [
        1.0000000000002
      ],
      stop: [
        1
      ],
      size: 10,
      alternate: false
    },
    {
      typeid: 'scanpointgenerator:generator/LineGenerator:1.0',
      axes: [
        'sample_x'
      ],
      units: [
        'mm'
      ],
      start: [
        1
      ],
      stop: [
        1.5
      ],
      size: 10,
      alternate: false
    }
  ],
  excluders: [],
  mutators: [],
  duration: 0.2,
  continuous: false
}
```

With this motor Info:
```
"sample_x": MotorInfo(
    "X", "BRICK1.CS1", 18.0, -2e-05, 0.0, 1.8, 1.0, "sample_x", 0.0, "mm"
),
"sample_y": MotorInfo(
    "Y", "BRICK1.CS1", 18.0, 2e-05, 0.0, 1.8, 1.0, "sample_y", 0.0, "mm"
),
```

Produces the following profile points:
```
time_arrays = {
    "sample_x": [0.0, 0.1, 0.284, 0.384],
    "sample_y": [0.0, 0.0, 0.384, 0.384],
}
velocity_arrays = {
    "sample_x": [0.0, -1.760563380282, -1.760563380282, 0.0],
    "sample_y": [0.0, -0.0, -0.0, 0.0],
}
```

This can be fixed by checking if the distance moved between points is a very small number, and rounding it to 0.