### PR TITLE
Ensure Seq Prescale value is not set during a scan

### DIFF
--- a/malcolm/modules/ADPandABlocks/doublebuffer.py
+++ b/malcolm/modules/ADPandABlocks/doublebuffer.py
@@ -242,14 +242,14 @@ class DoubleBuffer:
 
                 if table.repeats.value != 1:
                     logging.warning(
-                        "Repeats on Seq table {} should be set to '1', Malcolm has"
-                        "overwritten value for this scan".format(table.label.value)
+                        f"Repeats on Seq table {table.label.value} should be set to "
+                        "'1', Malcolm has overwritten value for this scan"
                     )
                     table.repeats.put_value(1)
                 if table.prescale.value != 0:
                     logging.warning(
-                        "Prescale on Seq table {} should be set to '0', Malcolm has"
-                        "overwritten value for this scan".format(table.label.value)
+                        f"Prescale on Seq table {table.label.value} should be set to "
+                        "'0', Malcolm has overwritten value for this scan"
                     )
                     table.prescale.put_value(0)
             self._finished = False

--- a/malcolm/modules/ADPandABlocks/doublebuffer.py
+++ b/malcolm/modules/ADPandABlocks/doublebuffer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, TypeVar
 
 from malcolm.core import Block, Context, Future
@@ -238,7 +239,19 @@ class DoubleBuffer:
             # The template sets repeats to 1 however older designs may not have
             # been updated.
             for table in self._table_map.values():
-                table.repeats.put_value(1)
+
+                if table.repeats.value != 1:
+                    logging.warning(
+                        "Repeats on Seq table {} should be set to '1', Malcolm has"
+                        "overwritten value for this scan".format(table.label.value)
+                    )
+                    table.repeats.put_value(1)
+                if table.prescale.value != 0:
+                    logging.warning(
+                        "Prescale on Seq table {} should be set to '0', Malcolm has"
+                        "overwritten value for this scan".format(table.label.value)
+                    )
+                    table.prescale.put_value(0)
             self._finished = False
 
     def _seq_active_handler(self, value: bool, table: str = "seqA") -> None:

--- a/tests/test_modules/test_ADPandABlocks/test_pandaseqtriggerpart.py
+++ b/tests/test_modules/test_ADPandABlocks/test_pandaseqtriggerpart.py
@@ -101,6 +101,9 @@ class SequencerPart(Part):
         attr = NumberMeta("int16", "repeats", writeable=True).create_attribute_model(1)
         registrar.add_attribute_model("repeats", attr, writeable_func=attr.set_value)
 
+        attr = NumberMeta("int16", "prescale", writeable=True).create_attribute_model(0)
+        registrar.add_attribute_model("prescale", attr, writeable_func=attr.set_value)
+
 
 class GatePart(Part):
     enable_set = None
@@ -772,6 +775,9 @@ class TestDoubleBuffer(ChildTestCase):
         # Check to ensure repeats is set correctly
         for table in self.db._table_map.values():
             assert table.repeats.value == 1
+        # Check to ensure Prescale is set correctly
+        for table in self.db._table_map.values():
+            assert table.prescale.value == 0
 
         self.seq_parts[1].table_set.assert_called_once()
         table1 = self.seq_parts[1].table_set.call_args[0][0]


### PR DESCRIPTION
If the Prescale parameter on either Sequencer table in the PandA design is set, it will cause the trigger timings to be incorrect. This change ensures that it is 0 during a scan, and logs a warning that the design has been changed by Malcolm.

This change also logs a message when Malcolm changes the value of Repeats, as this must be set to '1'.