### PR TITLE
Fix/panda acquire rbv

### DIFF
--- a/malcolm/modules/ADPandABlocks/__init__.py
+++ b/malcolm/modules/ADPandABlocks/__init__.py
@@ -1,1 +1,1 @@
-from . import parts
+from . import includes, parts

--- a/malcolm/modules/ADPandABlocks/controllers/pandarunnablecontroller.py
+++ b/malcolm/modules/ADPandABlocks/controllers/pandarunnablecontroller.py
@@ -4,6 +4,8 @@ from malcolm.modules import ADCore, builtin, pandablocks, scanning
 
 from ..parts.pandadatasetbussespart import PandADatasetBussesPart
 
+from ..includes import panda_adbase_parts
+
 with Anno("Prefix for areaDetector records"):
     APrefix = str
 # Re-export the things we are reusing from pandablocks
@@ -61,7 +63,7 @@ class PandARunnableController(
                 self._client, self.mri, block_name, block_data, self._doc_url_base
             )
             # Add the areaDetector control parts
-            _, ps = ADCore.includes.adbase_parts(prefix=self.prefix)
+            _, ps = panda_adbase_parts(prefix=self.prefix)
             for p in ps:
                 controller.add_part(p)
             child_part = ADCore.parts.DetectorDriverPart(

--- a/malcolm/modules/ADPandABlocks/controllers/pandarunnablecontroller.py
+++ b/malcolm/modules/ADPandABlocks/controllers/pandarunnablecontroller.py
@@ -1,10 +1,8 @@
 from annotypes import Anno
 
-from malcolm.modules import ADCore, builtin, pandablocks, scanning
+from malcolm.modules import ADCore, ADPandABlocks, builtin, pandablocks, scanning
 
 from ..parts.pandadatasetbussespart import PandADatasetBussesPart
-
-from ..includes import panda_adbase_parts
 
 with Anno("Prefix for areaDetector records"):
     APrefix = str
@@ -63,7 +61,7 @@ class PandARunnableController(
                 self._client, self.mri, block_name, block_data, self._doc_url_base
             )
             # Add the areaDetector control parts
-            _, ps = panda_adbase_parts(prefix=self.prefix)
+            _, ps = ADPandABlocks.includes.panda_adbase_parts(prefix=self.prefix)
             for p in ps:
                 controller.add_part(p)
             child_part = ADCore.parts.DetectorDriverPart(

--- a/malcolm/modules/ADPandABlocks/includes/__init__.py
+++ b/malcolm/modules/ADPandABlocks/includes/__init__.py
@@ -1,0 +1,5 @@
+from malcolm.yamlutil import check_yaml_names, make_include_creator
+
+panda_adbase_parts = make_include_creator(__file__, "panda_adbase_parts.yaml")
+
+__all__ = check_yaml_names(globals())

--- a/malcolm/modules/ADPandABlocks/includes/panda_adbase_parts.yaml
+++ b/malcolm/modules/ADPandABlocks/includes/panda_adbase_parts.yaml
@@ -1,0 +1,76 @@
+- builtin.parameters.string:
+    name: prefix
+    description: The root PV for the all records
+
+- builtin.parameters.string:
+    name: post_acquire_status
+    description: The value of ADStatus when acquire returns at the end of an acquisition
+    default: Idle
+
+- builtin.parameters.string:
+    name: num_images_pv_suffix
+    description: The PV suffix for number of images
+    default: NumImages
+
+- ADCore.includes.ndarraybase_parts:
+    prefix: $(prefix)
+
+- ca.parts.CAChoicePart:
+    name: imageMode
+    description: Whether to take 1, many, or unlimited images at start
+    pv: $(prefix):ImageMode
+    rbv_suffix: _RBV
+
+- ca.parts.CALongPart:
+    name: numImages
+    description: Number of images to take if imageMode=Multiple
+    pv: $(prefix):$(num_images_pv_suffix)
+    rbv_suffix: _RBV
+
+- ca.parts.CAActionPart:
+    name: start
+    description: Demand for starting acquisition
+    pv: $(prefix):Acquire
+    status_pv: $(prefix):DetectorState_RBV
+    good_status: $(post_acquire_status)
+
+- ca.parts.CAActionPart:
+    name: stop
+    description: Stop acquisition
+    pv: $(prefix):Acquire
+    value: 0
+    wait: False
+
+# For docs: before acquiring
+- ca.parts.CABooleanPart:
+    name: acquiring
+    description: If detector is currently acquiring
+    rbv: $(prefix):DetectorState_RBV
+
+- ca.parts.CAChoicePart:
+    name: triggerMode
+    description: What is triggering the detector to take frames
+    pv: $(prefix):TriggerMode
+    rbv_suffix: _RBV
+
+- ca.parts.CADoublePart:
+    name: exposure
+    description: Exposure time for each frame
+    pv: $(prefix):AcquireTime
+    rbv_suffix: _RBV
+
+- ca.parts.CADoublePart:
+    name: acquirePeriod
+    description: Duration of each frame including readout
+    pv: $(prefix):AcquirePeriod
+    rbv_suffix: _RBV
+
+- ca.parts.CALongPart:
+    name: arraySizeX
+    description: width of the image in pixels
+    rbv: $(prefix):ArraySizeX_RBV
+
+- ca.parts.CALongPart:
+      name: arraySizeY
+      description: height of the image in pixels
+      rbv: $(prefix):ArraySizeY_RBV

--- a/tests/test_modules/test_ADPandABlocks/test_pandablocksrunnablecontroller.py
+++ b/tests/test_modules/test_ADPandABlocks/test_pandablocksrunnablecontroller.py
@@ -27,7 +27,7 @@ class DSGather(Part):
 
 
 class PandABlocksRunnableControllerTest(unittest.TestCase):
-    @patch("malcolm.modules.ADCore.includes.adbase_parts")
+    @patch("malcolm.modules.ADPandABlocks.includes.panda_adbase_parts")
     @patch(
         "malcolm.modules.pandablocks.controllers."
         "pandamanagercontroller.PandABlocksClient"


### PR DESCRIPTION
Fixes an issue where the PandA doesn't disarm correctly at the end of a scan. A new scan would then be unable to start. It was observed that the detectorstate_RBV PV would update correctly to show that the PandA has disarmed, but the aquire_RBV PV wouldn't. This change means that Malcolm now monitors the detectorstate_RBV rather than the acquire_rbv. This has been tested and has been shown to overcome this problem.