### PR TITLE
Push PandA layout down to hardware on put

### DIFF
--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -274,7 +274,7 @@ class PandAManagerController(builtin.controllers.ManagerController):
             elif field_name == "LAYOUT" and v:
                 # Set the layout table first so that related fields are set after
                 # possible deletion
-                self._json_layout = json.loads(v)
+                self._json_layout = json.loads("".join(v))
                 x, y, visible = [], [], []
                 for name in self.layout.value.name:
                     visible.append(name in self._json_layout)

--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 from typing import Any, Dict, Sequence, Set, Tuple
 
@@ -325,6 +326,6 @@ class PandAManagerController(builtin.controllers.ManagerController):
             else:
                 self._json_layout.pop(name, "")
         if self._json_layout != old_json_layout:
-            self._client.set_table(
-                "*METADATA", "LAYOUT", [json.dumps(self._json_layout)]
-            )
+            # Custom encoding so the lines aren't too long and there aren't too many of them
+            lines = re.split(r'(?<=,) (?!"y")', json.dumps(self._json_layout))
+            self._client.set_table("*METADATA", "LAYOUT", lines)

--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import time
 from typing import Any, Dict, Sequence, Set, Tuple

--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -319,6 +319,7 @@ class PandAManagerController(builtin.controllers.ManagerController):
 
     def set_layout(self, value):
         super().set_layout(value)
+
         json_layout = {}
         for name, _, x, y, visible in self.layout.value.rows():
             if visible:

--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -325,4 +325,6 @@ class PandAManagerController(builtin.controllers.ManagerController):
             else:
                 self._json_layout.pop(name, "")
         if self._json_layout != old_json_layout:
-            self._client.set_table("*METADATA", "LAYOUT", [json.dumps(self._json_layout)])
+            self._client.set_table(
+                "*METADATA", "LAYOUT", [json.dumps(self._json_layout)]
+            )

--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -326,6 +326,6 @@ class PandAManagerController(builtin.controllers.ManagerController):
             else:
                 self._json_layout.pop(name, "")
         if self._json_layout != old_json_layout:
-            # Custom encoding so the lines aren't too long and there aren't too many of them
+            # Custom encoding so the lines aren't too long and there aren't too many
             lines = re.split(r'(?<=,) (?!"y")', json.dumps(self._json_layout))
             self._client.set_table("*METADATA", "LAYOUT", lines)

--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -324,4 +324,4 @@ class PandAManagerController(builtin.controllers.ManagerController):
             if visible:
                 json_layout[name] = dict(x=x, y=y)
         if self._json_layout != json_layout:
-            self._client.set_field("*METADATA", "LAYOUT", json.dumps(json_layout))
+            self._client.set_table("*METADATA", "LAYOUT", [json.dumps(json_layout)])

--- a/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandamanagercontroller.py
@@ -318,10 +318,11 @@ class PandAManagerController(builtin.controllers.ManagerController):
 
     def set_layout(self, value):
         super().set_layout(value)
-
-        json_layout = {}
+        old_json_layout = self._json_layout.copy()
         for name, _, x, y, visible in self.layout.value.rows():
             if visible:
-                json_layout[name] = dict(x=x, y=y)
-        if self._json_layout != json_layout:
-            self._client.set_table("*METADATA", "LAYOUT", [json.dumps(json_layout)])
+                self._json_layout[name] = dict(x=x, y=y)
+            else:
+                self._json_layout.pop(name, "")
+        if self._json_layout != old_json_layout:
+            self._client.set_table("*METADATA", "LAYOUT", [json.dumps(self._json_layout)])

--- a/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
+++ b/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
@@ -264,9 +264,9 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
         assert layout.x == [0.0, 0.0, 0.0, 0.0, 0.0]
         assert layout.y == [0.0, 0.0, 0.0, 0.0, 0.0]
         assert layout.visible == [False, False, False, False, False]
-        # Change coming from PandA
+        # Change coming from PandA with an extra block in it
         self.o.handle_changes(
-            [("*METADATA.LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}}')]
+            [("*METADATA.LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}, "HDF": {"x": 3.5, "y": 4.1}}')]
         )
         layout = panda.layout.value
         assert layout.name == ["PCOMP", "COUNTER", "TTLIN1", "TTLIN2", "PCAP"]
@@ -281,5 +281,5 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
         self.client.set_table.assert_called_once_with(
             "*METADATA",
             "LAYOUT",
-            ['{"COUNTER": {"x": 1.2, "y": 2.3}, "TTLIN1": {"x": 0.0, "y": 5.6}}'],
+            ['{"COUNTER": {"x": 1.2, "y": 2.3}, "HDF": {"x": 3.5, "y": 4.1}, "TTLIN1": {"x": 0.0, "y": 5.6}}'],
         )

--- a/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
+++ b/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
@@ -54,7 +54,7 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
             ["COUNTER.OUT.UNITS", ""],
             ["TTLIN1.VAL", "0"],
             ["TTLIN2.VAL", "0"],
-            ["*METADATA.LAYOUT", ""]
+            ["*METADATA.LAYOUT", ""],
         ]
         self.client.get_changes.return_value = changes
         pcap_bit_fields = {
@@ -260,22 +260,26 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
     def test_layout(self):
         panda = self.process.block_view("P")
         layout = panda.layout.value
-        assert layout.name == ['PCOMP', 'COUNTER', 'TTLIN1', 'TTLIN2', 'PCAP']
-        assert layout.x == [0., 0., 0., 0., 0.]
-        assert layout.y == [0., 0., 0., 0., 0.]
+        assert layout.name == ["PCOMP", "COUNTER", "TTLIN1", "TTLIN2", "PCAP"]
+        assert layout.x == [0.0, 0.0, 0.0, 0.0, 0.0]
+        assert layout.y == [0.0, 0.0, 0.0, 0.0, 0.0]
         assert layout.visible == [False, False, False, False, False]
         # Change coming from PandA
-        self.o.handle_changes([("*METADATA.LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}}')])
+        self.o.handle_changes(
+            [("*METADATA.LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}}')]
+        )
         layout = panda.layout.value
-        assert layout.name == ['PCOMP', 'COUNTER', 'TTLIN1', 'TTLIN2', 'PCAP']
-        assert layout.x == [0., 1.2, 0., 0., 0.]
-        assert layout.y == [0., 2.3, 0., 0., 0.]
+        assert layout.name == ["PCOMP", "COUNTER", "TTLIN1", "TTLIN2", "PCAP"]
+        assert layout.x == [0.0, 1.2, 0.0, 0.0, 0.0]
+        assert layout.y == [0.0, 2.3, 0.0, 0.0, 0.0]
         assert layout.visible == [False, True, False, False, False]
         # Change coming from Malcolm
         layout = panda.layout.value
         layout.visible = [False, True, True, False, False]
-        layout.y = [0., 2.3, 5.6, 0., 0.]
+        layout.y = [0.0, 2.3, 5.6, 0.0, 0.0]
         panda.layout.put_value(layout)
         self.client.set_field.assert_called_once_with(
-            "*METADATA", "LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}, "TTLIN1": {"x": 0.0, "y": 5.6}}'
+            "*METADATA",
+            "LAYOUT",
+            '{"COUNTER": {"x": 1.2, "y": 2.3}, "TTLIN1": {"x": 0.0, "y": 5.6}}',
         )

--- a/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
+++ b/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
@@ -54,6 +54,7 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
             ["COUNTER.OUT.UNITS", ""],
             ["TTLIN1.VAL", "0"],
             ["TTLIN2.VAL", "0"],
+            ["*METADATA.LAYOUT", ""]
         ]
         self.client.get_changes.return_value = changes
         pcap_bit_fields = {
@@ -254,4 +255,27 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
         pcomp.label.put_value("Very new")
         self.client.set_field.assert_called_once_with(
             "*METADATA", "LABEL_PCOMP1", "Very new"
+        )
+
+    def test_layout(self):
+        panda = self.process.block_view("P")
+        layout = panda.layout.value
+        assert layout.name == ['PCOMP', 'COUNTER', 'TTLIN1', 'TTLIN2', 'PCAP']
+        assert layout.x == [0., 0., 0., 0., 0.]
+        assert layout.y == [0., 0., 0., 0., 0.]
+        assert layout.visible == [False, False, False, False, False]
+        # Change coming from PandA
+        self.o.handle_changes([("*METADATA.LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}}')])
+        layout = panda.layout.value
+        assert layout.name == ['PCOMP', 'COUNTER', 'TTLIN1', 'TTLIN2', 'PCAP']
+        assert layout.x == [0., 1.2, 0., 0., 0.]
+        assert layout.y == [0., 2.3, 0., 0., 0.]
+        assert layout.visible == [False, True, False, False, False]
+        # Change coming from Malcolm
+        layout = panda.layout.value
+        layout.visible = [False, True, True, False, False]
+        layout.y = [0., 2.3, 5.6, 0., 0.]
+        panda.layout.put_value(layout)
+        self.client.set_field.assert_called_once_with(
+            "*METADATA", "LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}, "TTLIN1": {"x": 0.0, "y": 5.6}}'
         )

--- a/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
+++ b/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
@@ -269,7 +269,10 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
             [
                 (
                     "*METADATA.LAYOUT",
-                    '{"COUNTER": {"x": 1.2, "y": 2.3}, "HDF": {"x": 3.5, "y": 4.1}}',
+                    [
+                        '{"COUNTER": {"x": 1.2, "y": 2.3},',
+                        '"HDF": {"x": 3.5, "y": 4.1}}',
+                    ],
                 )
             ]
         )
@@ -287,8 +290,8 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
             "*METADATA",
             "LAYOUT",
             [
-                '{"COUNTER": {"x": 1.2, "y": 2.3},'
-                ' "HDF": {"x": 3.5, "y": 4.1},'
-                ' "TTLIN1": {"x": 0.0, "y": 5.6}}'
+                '{"COUNTER": {"x": 1.2, "y": 2.3},',
+                '"HDF": {"x": 3.5, "y": 4.1},',
+                '"TTLIN1": {"x": 0.0, "y": 5.6}}',
             ],
         )

--- a/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
+++ b/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
@@ -278,8 +278,8 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
         layout.visible = [False, True, True, False, False]
         layout.y = [0.0, 2.3, 5.6, 0.0, 0.0]
         panda.layout.put_value(layout)
-        self.client.set_field.assert_called_once_with(
+        self.client.set_table.assert_called_once_with(
             "*METADATA",
             "LAYOUT",
-            '{"COUNTER": {"x": 1.2, "y": 2.3}, "TTLIN1": {"x": 0.0, "y": 5.6}}',
+            ['{"COUNTER": {"x": 1.2, "y": 2.3}, "TTLIN1": {"x": 0.0, "y": 5.6}}'],
         )

--- a/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
+++ b/tests/test_modules/test_pandablocks/test_pandablocksmanagercontroller.py
@@ -266,7 +266,12 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
         assert layout.visible == [False, False, False, False, False]
         # Change coming from PandA with an extra block in it
         self.o.handle_changes(
-            [("*METADATA.LAYOUT", '{"COUNTER": {"x": 1.2, "y": 2.3}, "HDF": {"x": 3.5, "y": 4.1}}')]
+            [
+                (
+                    "*METADATA.LAYOUT",
+                    '{"COUNTER": {"x": 1.2, "y": 2.3}, "HDF": {"x": 3.5, "y": 4.1}}',
+                )
+            ]
         )
         layout = panda.layout.value
         assert layout.name == ["PCOMP", "COUNTER", "TTLIN1", "TTLIN2", "PCAP"]
@@ -281,5 +286,9 @@ class PandABlocksManagerControllerTest(unittest.TestCase):
         self.client.set_table.assert_called_once_with(
             "*METADATA",
             "LAYOUT",
-            ['{"COUNTER": {"x": 1.2, "y": 2.3}, "HDF": {"x": 3.5, "y": 4.1}, "TTLIN1": {"x": 0.0, "y": 5.6}}'],
+            [
+                '{"COUNTER": {"x": 1.2, "y": 2.3},'
+                ' "HDF": {"x": 3.5, "y": 4.1},'
+                ' "TTLIN1": {"x": 0.0, "y": 5.6}}'
+            ],
         )


### PR DESCRIPTION
This stores the layout table on PandA as `*METADATA.LAYOUT`. Format is:

`{block.name: {"x": block.x, "y": block.y} for block in blocks if block.visible}`

E.g.
`{"COUNTER1": {"x": 1.2, "y": 2.3}, "TTLIN1": {"x": 0.0, "y": 5.6}}`
