### PR TITLE
Set brick to calculate velocity profile 

### DIFF
--- a/malcolm/modules/pmac/blocks/pmac_trajectory_block.yaml
+++ b/malcolm/modules/pmac/blocks/pmac_trajectory_block.yaml
@@ -218,3 +218,9 @@
     description: the version number of the pmac's trajectory program
     rbv: $(pv_prefix):ProgramVersion_RBV
     config: False
+
+- ca.parts.CAChoicePart:
+    name: calculateVelocities
+    description: Does the brick need to calculate the velocity profile
+    pv: $(pv_prefix):ProfileCalcVel
+    config: False

--- a/malcolm/modules/pmac/parts/pmactrajectorypart.py
+++ b/malcolm/modules/pmac/parts/pmactrajectorypart.py
@@ -110,9 +110,9 @@ class PmacTrajectoryPart(builtin.parts.ChildPart):
         z: ADemandTrajectory = None,
     ) -> None:
         child = context.block_view(self.mri)
-
+        child.calculateVelocities.put_value("YES")
         # make sure a matching trajectory program is installed on the pmac
-        if child.trajectoryProgVersion.value != TRAJECTORY_PROGRAM_NUM:
+        if child.trajectoryProgVersion.value < TRAJECTORY_PROGRAM_NUM:
             if child.trajectoryProgVersion.value >= FALLBACK_TRAJ_PROGRAM_NUM:
                 self.log.warning(
                     f"pmac trajectory program is version {FALLBACK_TRAJ_PROGRAM_NUM}"


### PR DESCRIPTION
These changes set the PV {BRICK}:ProfileCalcVel to YES, so the brick creates the Velocity profile based off the provided VelocityMode profile. 

(Bluesky testing has been setting this to NO, and has then messed up motion for Malcolm scans).

This PV was added in pmac 2-6-0 and will become a minimum requirement for Malcolm with this change.

This change also stops Malcolm raising warnings about an incompatible motion program, when using Motion Program 4.0