### PR TITLE
Ignore the MODE attribute from a table field

### DIFF
--- a/malcolm/modules/pandablocks/controllers/pandablockcontroller.py
+++ b/malcolm/modules/pandablocks/controllers/pandablockcontroller.py
@@ -230,7 +230,7 @@ class PandABlockController(builtin.controllers.BasicController):
             self._make_mux(field_name, field_data, Port.INT32)
         elif typ == "table":
             self._make_table(field_name, field_data)
-            for suffix in ("QUEUED_LINES",):
+            for suffix in ("QUEUED_LINES","MODE"):
                 self.field_parts[f"{field_name}.{suffix}"] = None
         else:
             raise ValueError(f"Unknown type {typ!r} subtype {subtyp!r}")


### PR DESCRIPTION
Similar to #394 but this needs to be done with the Mode attribute now due to this [change](https://github.com/PandABlocks/PandABlocks-server/issues/73#event-22671098253) to PandABlocks server. 